### PR TITLE
Add support for generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+_example

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea
-_example

--- a/checker.go
+++ b/checker.go
@@ -193,7 +193,7 @@ func checkSingle[S State[S]](model Model[S], history []entry, computePartial boo
 		}
 		if entry.match != nil {
 			matching := entry.match // the return entry
-			ok, newState := model.Step(state, entry.value, matching.value)
+			ok, newState := model.Step(state.Clone(), entry.value, matching.value)
 			if ok {
 				newLinearized := linearized.clone().set(uint(entry.id))
 				newCacheEntry := cacheEntry[S]{newLinearized, newState}

--- a/checker.go
+++ b/checker.go
@@ -53,7 +53,7 @@ func (a byTime) Less(i, j int) bool {
 	return a[i].kind == callEntry && a[j].kind == returnEntry
 }
 
-func makeEntries(history []Operation) []entry {
+func makeEntries[I any, O any](history []Operation[I, O]) []entry {
 	var entries []entry = nil
 	id := 0
 	for _, elem := range history {
@@ -105,15 +105,15 @@ func length(n *node) int {
 	return l
 }
 
-func renumber(events []Event) []Event {
-	var e []Event
+func renumber[I any, O any](events []Event[I, O]) []Event[I, O] {
+	var e []Event[I, O]
 	m := make(map[int]int) // renumbering
 	id := 0
 	for _, v := range events {
 		if r, ok := m[v.Id]; ok {
-			e = append(e, Event{v.ClientId, v.Kind, v.Value, r})
+			e = append(e, Event[I, O]{v.ClientId, v.Kind, v.Value, r})
 		} else {
-			e = append(e, Event{v.ClientId, v.Kind, v.Value, id})
+			e = append(e, Event[I, O]{v.ClientId, v.Kind, v.Value, id})
 			m[v.Id] = id
 			id++
 		}
@@ -121,7 +121,7 @@ func renumber(events []Event) []Event {
 	return e
 }
 
-func convertEntries(events []Event) []entry {
+func convertEntries[I any, O any](events []Event[I, O]) []entry {
 	var entries []entry
 	for i, elem := range events {
 		kind := callEntry
@@ -270,10 +270,10 @@ func checkSingle[S State[S], I any, O any](model Model[S, I, O], history []entry
 
 func fillDefault[S State[S], I any, O any](model Model[S, I, O]) Model[S, I, O] {
 	if model.Partition == nil {
-		model.Partition = noPartition
+		model.Partition = noPartition[I, O]
 	}
 	if model.PartitionEvent == nil {
-		model.PartitionEvent = noPartitionEvent
+		model.PartitionEvent = noPartitionEvent[I, O]
 	}
 	if model.DescribeOperation == nil {
 		model.DescribeOperation = defaultDescribeOperation[I, O]
@@ -360,7 +360,7 @@ loop:
 	return result, info
 }
 
-func checkEvents[S State[S], I any, O any](model Model[S, I, O], history []Event, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkEvents[S State[S], I any, O any](model Model[S, I, O], history []Event[I, O], verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
 	model = fillDefault(model)
 	partitions := model.PartitionEvent(history)
 	l := make([][]entry, len(partitions))
@@ -370,7 +370,7 @@ func checkEvents[S State[S], I any, O any](model Model[S, I, O], history []Event
 	return checkParallel(model, l, verbose, timeout)
 }
 
-func checkOperations[S State[S], I any, O any](model Model[S, I, O], history []Operation, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkOperations[S State[S], I any, O any](model Model[S, I, O], history []Operation[I, O], verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
 	model = fillDefault(model)
 	partitions := model.Partition(history)
 	l := make([][]entry, len(partitions))

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/anishathalye/porcupine
 
-go 1.13
+go 1.19

--- a/model.go
+++ b/model.go
@@ -72,7 +72,7 @@ type Event struct {
 // to write models, including models that include partition functions.
 //
 // [test code]: https://github.com/anishathalye/porcupine/blob/master/porcupine_test.go
-type Model[S State[S]] struct {
+type Model[S State[S], I any, O any] struct {
 	// Partition functions, such that a history is linearizable if and only
 	// if each partition is linearizable. If left nil, this package will
 	// skip partitioning.
@@ -83,11 +83,11 @@ type Model[S State[S]] struct {
 	// Step function for the system. Returns whether the system
 	// could take this step with the given inputs and outputs and also
 	// returns the new state. This function can mutate the state.
-	Step func(state S, input interface{}, output interface{}) (bool, S)
+	Step func(state S, input I, output O) (bool, S)
 	// For visualization, describe an operation as a string. For example,
 	// "Get('x') -> 'y'". Can be omitted if you're not producing
 	// visualizations.
-	DescribeOperation func(input interface{}, output interface{}) string
+	DescribeOperation func(input I, output O) string
 }
 
 // noPartition is a fallback partition function that partitions the history
@@ -104,7 +104,7 @@ func noPartitionEvent(history []Event) [][]Event {
 
 // defaultDescribeOperation is a fallback to convert an operation to a string.
 // It renders inputs and outputs using the "%v" format specifier.
-func defaultDescribeOperation(input interface{}, output interface{}) string {
+func defaultDescribeOperation[I any, O any](input I, output O) string {
 	return fmt.Sprintf("%v -> %v", input, output)
 }
 

--- a/model.go
+++ b/model.go
@@ -56,17 +56,13 @@ type Event struct {
 
 // A Model is a sequential specification of a system.
 //
-// Note: models in this package are expected to be purely functional. That is,
-// the model Step function should not modify the given state (or input or
-// output), but return a new state.
-//
-// Only the Init, Step, and Equal functions are necessary to specify if you
+// Only the Init and Step functions are necessary to specify if you
 // just want to test histories for linearizability.
 //
 // Implementing the partition functions can greatly improve performance. If
 // you're implementing the partition function, the model Init and Step
 // functions can be per-partition. For example, if your specification is for a
-// key-value store and you partition by key, then the per-partition state
+// key-value store, and you partition by key, then the per-partition state
 // representation can just be a single value rather than a map.
 //
 // Implementing DescribeOperation and DescribeState will produce nicer
@@ -86,8 +82,7 @@ type Model[S State[S]] struct {
 	Init func() S
 	// Step function for the system. Returns whether the system
 	// could take this step with the given inputs and outputs and also
-	// returns the new state. This function must be a pure function: it
-	// cannot mutate the given state.
+	// returns the new state. This function can mutate the state.
 	Step func(state S, input interface{}, output interface{}) (bool, S)
 	// For visualization, describe an operation as a string. For example,
 	// "Get('x') -> 'y'". Can be omitted if you're not producing

--- a/model.go
+++ b/model.go
@@ -84,22 +84,15 @@ type Model[S State[S]] struct {
 	PartitionEvent func(history []Event) [][]Event
 	// Init returns the initial state of the system
 	Init func() S
-	// Step function for the system. Returns whether or not the system
+	// Step function for the system. Returns whether the system
 	// could take this step with the given inputs and outputs and also
 	// returns the new state. This function must be a pure function: it
 	// cannot mutate the given state.
 	Step func(state S, input interface{}, output interface{}) (bool, S)
-	// Equality on states. If left nil, this package will use == as a
-	// fallback ([ShallowEqual]).
-	Equal func(state1, state2 interface{}) bool
 	// For visualization, describe an operation as a string. For example,
 	// "Get('x') -> 'y'". Can be omitted if you're not producing
 	// visualizations.
 	DescribeOperation func(input interface{}, output interface{}) string
-	// For visualization purposes, describe a state as a string. For
-	// example, "{'x' -> 'y', 'z' -> 'w'}". Can be omitted if you're not
-	// producing visualizations.
-	DescribeState func(state interface{}) string
 }
 
 // noPartition is a fallback partition function that partitions the history
@@ -114,22 +107,10 @@ func noPartitionEvent(history []Event) [][]Event {
 	return [][]Event{history}
 }
 
-// shallowEqual is a fallback equality function that compares two states using
-// ==.
-func shallowEqual(state1, state2 interface{}) bool {
-	return state1 == state2
-}
-
 // defaultDescribeOperation is a fallback to convert an operation to a string.
 // It renders inputs and outputs using the "%v" format specifier.
 func defaultDescribeOperation(input interface{}, output interface{}) string {
 	return fmt.Sprintf("%v -> %v", input, output)
-}
-
-// defaultDescribeState is a fallback to convert a state to a string. It
-// renders the state using the "%v" format specifier.
-func defaultDescribeState(state interface{}) string {
-	return fmt.Sprintf("%v", state)
 }
 
 // A CheckResult is the result of a linearizability check.

--- a/porcupine.go
+++ b/porcupine.go
@@ -3,7 +3,7 @@ package porcupine
 import "time"
 
 // CheckOperations checks whether a history is linearizable.
-func CheckOperations(model Model, history []Operation) bool {
+func CheckOperations[S State[S]](model Model[S], history []Operation) bool {
 	res, _ := checkOperations(model, history, false, 0)
 	return res == Ok
 }
@@ -12,7 +12,7 @@ func CheckOperations(model Model, history []Operation) bool {
 // timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckOperationsTimeout(model Model, history []Operation, timeout time.Duration) CheckResult {
+func CheckOperationsTimeout[S State[S]](model Model[S], history []Operation, timeout time.Duration) CheckResult {
 	res, _ := checkOperations(model, history, false, timeout)
 	return res
 }
@@ -21,12 +21,12 @@ func CheckOperationsTimeout(model Model, history []Operation, timeout time.Durat
 // computing data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckOperationsVerbose(model Model, history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckOperationsVerbose[S State[S]](model Model[S], history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkOperations(model, history, true, timeout)
 }
 
 // CheckEvents checks whether a history is linearizable.
-func CheckEvents(model Model, history []Event) bool {
+func CheckEvents[S State[S]](model Model[S], history []Event) bool {
 	res, _ := checkEvents(model, history, false, 0)
 	return res == Ok
 }
@@ -34,7 +34,7 @@ func CheckEvents(model Model, history []Event) bool {
 // CheckEventsTimeout checks whether a history is linearizable, with a timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckEventsTimeout(model Model, history []Event, timeout time.Duration) CheckResult {
+func CheckEventsTimeout[S State[S]](model Model[S], history []Event, timeout time.Duration) CheckResult {
 	res, _ := checkEvents(model, history, false, timeout)
 	return res
 }
@@ -43,6 +43,6 @@ func CheckEventsTimeout(model Model, history []Event, timeout time.Duration) Che
 // data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckEventsVerbose(model Model, history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckEventsVerbose[S State[S]](model Model[S], history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkEvents(model, history, true, timeout)
 }

--- a/porcupine.go
+++ b/porcupine.go
@@ -3,7 +3,7 @@ package porcupine
 import "time"
 
 // CheckOperations checks whether a history is linearizable.
-func CheckOperations[S State[S]](model Model[S], history []Operation) bool {
+func CheckOperations[S State[S], I any, O any](model Model[S, I, O], history []Operation) bool {
 	res, _ := checkOperations(model, history, false, 0)
 	return res == Ok
 }
@@ -12,7 +12,7 @@ func CheckOperations[S State[S]](model Model[S], history []Operation) bool {
 // timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckOperationsTimeout[S State[S]](model Model[S], history []Operation, timeout time.Duration) CheckResult {
+func CheckOperationsTimeout[S State[S], I any, O any](model Model[S, I, O], history []Operation, timeout time.Duration) CheckResult {
 	res, _ := checkOperations(model, history, false, timeout)
 	return res
 }
@@ -21,12 +21,12 @@ func CheckOperationsTimeout[S State[S]](model Model[S], history []Operation, tim
 // computing data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckOperationsVerbose[S State[S]](model Model[S], history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckOperationsVerbose[S State[S], I any, O any](model Model[S, I, O], history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkOperations(model, history, true, timeout)
 }
 
 // CheckEvents checks whether a history is linearizable.
-func CheckEvents[S State[S]](model Model[S], history []Event) bool {
+func CheckEvents[S State[S], I any, O any](model Model[S, I, O], history []Event) bool {
 	res, _ := checkEvents(model, history, false, 0)
 	return res == Ok
 }
@@ -34,7 +34,7 @@ func CheckEvents[S State[S]](model Model[S], history []Event) bool {
 // CheckEventsTimeout checks whether a history is linearizable, with a timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckEventsTimeout[S State[S]](model Model[S], history []Event, timeout time.Duration) CheckResult {
+func CheckEventsTimeout[S State[S], I any, O any](model Model[S, I, O], history []Event, timeout time.Duration) CheckResult {
 	res, _ := checkEvents(model, history, false, timeout)
 	return res
 }
@@ -43,6 +43,6 @@ func CheckEventsTimeout[S State[S]](model Model[S], history []Event, timeout tim
 // data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckEventsVerbose[S State[S]](model Model[S], history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckEventsVerbose[S State[S], I any, O any](model Model[S, I, O], history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkEvents(model, history, true, timeout)
 }

--- a/porcupine.go
+++ b/porcupine.go
@@ -3,7 +3,7 @@ package porcupine
 import "time"
 
 // CheckOperations checks whether a history is linearizable.
-func CheckOperations[S State[S], I any, O any](model Model[S, I, O], history []Operation) bool {
+func CheckOperations[S State[S], I any, O any](model Model[S, I, O], history []Operation[I, O]) bool {
 	res, _ := checkOperations(model, history, false, 0)
 	return res == Ok
 }
@@ -12,7 +12,7 @@ func CheckOperations[S State[S], I any, O any](model Model[S, I, O], history []O
 // timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckOperationsTimeout[S State[S], I any, O any](model Model[S, I, O], history []Operation, timeout time.Duration) CheckResult {
+func CheckOperationsTimeout[S State[S], I any, O any](model Model[S, I, O], history []Operation[I, O], timeout time.Duration) CheckResult {
 	res, _ := checkOperations(model, history, false, timeout)
 	return res
 }
@@ -21,12 +21,12 @@ func CheckOperationsTimeout[S State[S], I any, O any](model Model[S, I, O], hist
 // computing data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckOperationsVerbose[S State[S], I any, O any](model Model[S, I, O], history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckOperationsVerbose[S State[S], I any, O any](model Model[S, I, O], history []Operation[I, O], timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkOperations(model, history, true, timeout)
 }
 
 // CheckEvents checks whether a history is linearizable.
-func CheckEvents[S State[S], I any, O any](model Model[S, I, O], history []Event) bool {
+func CheckEvents[S State[S], I any, O any](model Model[S, I, O], history []Event[I, O]) bool {
 	res, _ := checkEvents(model, history, false, 0)
 	return res == Ok
 }
@@ -34,7 +34,7 @@ func CheckEvents[S State[S], I any, O any](model Model[S, I, O], history []Event
 // CheckEventsTimeout checks whether a history is linearizable, with a timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckEventsTimeout[S State[S], I any, O any](model Model[S, I, O], history []Event, timeout time.Duration) CheckResult {
+func CheckEventsTimeout[S State[S], I any, O any](model Model[S, I, O], history []Event[I, O], timeout time.Duration) CheckResult {
 	res, _ := checkEvents(model, history, false, timeout)
 	return res
 }
@@ -43,6 +43,6 @@ func CheckEventsTimeout[S State[S], I any, O any](model Model[S, I, O], history 
 // data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckEventsVerbose[S State[S], I any, O any](model Model[S, I, O], history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckEventsVerbose[S State[S], I any, O any](model Model[S, I, O], history []Event[I, O], timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkEvents(model, history, true, timeout)
 }

--- a/porcupine_test.go
+++ b/porcupine_test.go
@@ -1536,9 +1536,6 @@ func TestSetModel(t *testing.T) {
 			sort.Ints(out.values)
 			return out.unknown || reflect.DeepEqual(st, out.values), out.values
 		},
-		Equal: func(state1, state2 interface{}) bool {
-			return reflect.DeepEqual(state1, state2)
-		},
 	}
 
 	events := []Event{

--- a/porcupine_test.go
+++ b/porcupine_test.go
@@ -44,6 +44,24 @@ func (i intSliceState) String() string {
 	return ""
 }
 
+type mapState map[string]string
+
+func (m mapState) Clone() mapState {
+	m2 := make(map[string]string)
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
+}
+
+func (m mapState) Equals(otherState mapState) bool {
+	return reflect.DeepEqual(m, otherState)
+}
+
+func (m mapState) String() string {
+	return ""
+}
+
 type stringState string
 
 func (i stringState) Clone() stringState {
@@ -91,7 +109,7 @@ func TestRegisterModel(t *testing.T) {
 	// examples taken from http://nil.csail.mit.edu/6.824/2017/quizzes/q2-17-ans.pdf
 	// section VII
 
-	ops := []Operation{
+	ops := []Operation[registerInput, int]{
 		{0, registerInput{false, 100}, 0, 0, 100},
 		{1, registerInput{true, 0}, 25, 100, 75},
 		{2, registerInput{true, 0}, 30, 0, 60},
@@ -102,7 +120,7 @@ func TestRegisterModel(t *testing.T) {
 	}
 
 	// same example as above, but with Event
-	events := []Event{
+	events := []Event[registerInput, int]{
 		{0, CallEvent, registerInput{false, 100}, 0},
 		{1, CallEvent, registerInput{true, 0}, 1},
 		{2, CallEvent, registerInput{true, 0}, 2},
@@ -115,7 +133,7 @@ func TestRegisterModel(t *testing.T) {
 		t.Fatal("expected operations to be linearizable")
 	}
 
-	ops = []Operation{
+	ops = []Operation[registerInput, int]{
 		{0, registerInput{false, 200}, 0, 0, 100},
 		{1, registerInput{true, 0}, 10, 200, 30},
 		{2, registerInput{true, 0}, 40, 0, 90},
@@ -126,7 +144,7 @@ func TestRegisterModel(t *testing.T) {
 	}
 
 	// same example as above, but with Event
-	events = []Event{
+	events = []Event[registerInput, int]{
 		{0, CallEvent, registerInput{false, 200}, 0},
 		{1, CallEvent, registerInput{true, 0}, 1},
 		{1, ReturnEvent, 200, 1},
@@ -141,7 +159,7 @@ func TestRegisterModel(t *testing.T) {
 }
 
 func TestZeroDuration(t *testing.T) {
-	ops := []Operation{
+	ops := []Operation[registerInput, int]{
 		{0, registerInput{false, 100}, 0, 0, 100},
 		{1, registerInput{true, 0}, 25, 100, 75},
 		{2, registerInput{true, 0}, 30, 0, 30},
@@ -154,7 +172,7 @@ func TestZeroDuration(t *testing.T) {
 
 	visualizeTempFile(t, registerModel, info)
 
-	ops = []Operation{
+	ops = []Operation[registerInput, int]{
 		{0, registerInput{false, 200}, 0, 0, 100},
 		{1, registerInput{true, 0}, 10, 200, 10},
 		{2, registerInput{true, 0}, 10, 200, 10},
@@ -229,7 +247,7 @@ var etcdModel = Model[intState, etcdInput, etcdOutput]{
 	},
 }
 
-func parseJepsenLog(filename string) []Event {
+func parseJepsenLog(filename string) []Event[etcdInput, etcdOutput] {
 	file, err := os.Open(filename)
 	if err != nil {
 		panic("can't open file")
@@ -246,7 +264,7 @@ func parseJepsenLog(filename string) []Event {
 	returnCas, _ := regexp.Compile(`^INFO\s+jepsen\.util\s+-\s+(\d+)\s+:(ok|fail)\s+:cas\s+\[(\d+)\s+(\d+)\]$`)
 	timeoutRead, _ := regexp.Compile(`^INFO\s+jepsen\.util\s+-\s+(\d+)\s+:fail\s+:read\s+:timed-out$`)
 
-	var events []Event = nil
+	var events []Event[etcdInput, etcdOutput] = nil
 
 	id := 0
 	procIdMap := make(map[int]int)
@@ -266,14 +284,14 @@ func parseJepsenLog(filename string) []Event {
 		case invokeRead.MatchString(line):
 			args := invokeRead.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
-			events = append(events, Event{proc, CallEvent, etcdInput{op: 0}, id})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, CallEvent, etcdInput{op: 0}, id})
 			procIdMap[proc] = id
 			id++
 		case invokeWrite.MatchString(line):
 			args := invokeWrite.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
 			value, _ := strconv.Atoi(args[2])
-			events = append(events, Event{proc, CallEvent, etcdInput{op: 1, arg1: value}, id})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, CallEvent, etcdInput{op: 1, arg1: value}, id})
 			procIdMap[proc] = id
 			id++
 		case invokeCas.MatchString(line):
@@ -281,7 +299,7 @@ func parseJepsenLog(filename string) []Event {
 			proc, _ := strconv.Atoi(args[1])
 			from, _ := strconv.Atoi(args[2])
 			to, _ := strconv.Atoi(args[3])
-			events = append(events, Event{proc, CallEvent, etcdInput{op: 2, arg1: from, arg2: to}, id})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, CallEvent, etcdInput{op: 2, arg1: from, arg2: to}, id})
 			procIdMap[proc] = id
 			id++
 		case returnRead.MatchString(line):
@@ -295,19 +313,19 @@ func parseJepsenLog(filename string) []Event {
 			}
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
-			events = append(events, Event{proc, ReturnEvent, etcdOutput{exists: exists, value: value}, matchId})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, ReturnEvent, etcdOutput{exists: exists, value: value}, matchId})
 		case returnWrite.MatchString(line):
 			args := returnWrite.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
-			events = append(events, Event{proc, ReturnEvent, etcdOutput{}, matchId})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, ReturnEvent, etcdOutput{}, matchId})
 		case returnCas.MatchString(line):
 			args := returnCas.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
-			events = append(events, Event{proc, ReturnEvent, etcdOutput{ok: args[2] == "ok"}, matchId})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, ReturnEvent, etcdOutput{ok: args[2] == "ok"}, matchId})
 		case timeoutRead.MatchString(line):
 			// timing out a read and then continuing operations is fine
 			// we could just delete the read from the events, but we do this the lazy way
@@ -316,12 +334,12 @@ func parseJepsenLog(filename string) []Event {
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
 			// okay to put the return here in the history
-			events = append(events, Event{proc, ReturnEvent, etcdOutput{unknown: true}, matchId})
+			events = append(events, Event[etcdInput, etcdOutput]{proc, ReturnEvent, etcdOutput{unknown: true}, matchId})
 		}
 	}
 
 	for proc, matchId := range procIdMap {
-		events = append(events, Event{proc, ReturnEvent, etcdOutput{unknown: true}, matchId})
+		events = append(events, Event[etcdInput, etcdOutput]{proc, ReturnEvent, etcdOutput{unknown: true}, matchId})
 	}
 
 	return events
@@ -1177,10 +1195,10 @@ type kvOutput struct {
 }
 
 var kvModel = Model[stringState, kvInput, kvOutput]{
-	Partition: func(history []Operation) [][]Operation {
-		m := make(map[string][]Operation)
+	Partition: func(history []Operation[kvInput, kvOutput]) [][]Operation[kvInput, kvOutput] {
+		m := make(map[string][]Operation[kvInput, kvOutput])
 		for _, v := range history {
-			key := v.Input.(kvInput).key
+			key := v.Input.key
 			m[key] = append(m[key], v)
 		}
 		keys := make([]string, 0, len(m))
@@ -1188,14 +1206,14 @@ var kvModel = Model[stringState, kvInput, kvOutput]{
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		ret := make([][]Operation, 0, len(keys))
+		ret := make([][]Operation[kvInput, kvOutput], 0, len(keys))
 		for _, k := range keys {
 			ret = append(ret, m[k])
 		}
 		return ret
 	},
-	PartitionEvent: func(history []Event) [][]Event {
-		m := make(map[string][]Event)
+	PartitionEvent: func(history []Event[kvInput, kvOutput]) [][]Event[kvInput, kvOutput] {
+		m := make(map[string][]Event[kvInput, kvOutput])
 		match := make(map[int]string) // id -> key
 		for _, v := range history {
 			if v.Kind == CallEvent {
@@ -1207,7 +1225,7 @@ var kvModel = Model[stringState, kvInput, kvOutput]{
 				m[key] = append(m[key], v)
 			}
 		}
-		var ret [][]Event
+		var ret [][]Event[kvInput, kvOutput]
 		for _, v := range m {
 			ret = append(ret, v)
 		}
@@ -1245,43 +1263,25 @@ var kvModel = Model[stringState, kvInput, kvOutput]{
 //
 // this is a silly way to do things (it's way slower!) but good for
 // demonstration, testing, and benchmark purposes
-var kvNoPartitionModel = Model{
-	Init: func() interface{} {
-		return make(map[string]string)
-	},
-	Step: func(state, input, output interface{}) (bool, interface{}) {
-		inp := input.(kvInput)
-		out := output.(kvOutput)
-		st := state.(map[string]string)
+var kvNoPartitionModel = Model[mapState, kvInput, kvOutput]{
+	Init: func() mapState { return mapState{} },
+	Step: func(st mapState, inp kvInput, out kvOutput) (bool, mapState) {
 		if inp.op == 0 {
 			// get
-			return out.value == st[inp.key], state
+			return out.value == st[inp.key], st
 		} else if inp.op == 1 {
 			// put
-			st2 := cloneMap(st)
-			st2[inp.key] = inp.value
-			return true, st2
+			st[inp.key] = inp.value
+			return true, st
 		} else {
 			// append
-			st2 := cloneMap(st)
-			st2[inp.key] = st2[inp.key] + inp.value
-			return true, st2
+			st[inp.key] = st[inp.key] + inp.value
+			return true, st
 		}
 	},
-	Equal: func(state1, state2 interface{}) bool {
-		return reflect.DeepEqual(state1, state2)
-	},
 }
 
-func cloneMap(m map[string]string) map[string]string {
-	m2 := make(map[string]string)
-	for k, v := range m {
-		m2[k] = v
-	}
-	return m2
-}
-
-func parseKvLog(filename string) []Event {
+func parseKvLog(filename string) []Event[kvInput, kvOutput] {
 	file, err := os.Open(filename)
 	if err != nil {
 		panic("can't open file")
@@ -1297,7 +1297,7 @@ func parseKvLog(filename string) []Event {
 	returnPut, _ := regexp.Compile(`{:process (\d+), :type :ok, :f :put, :key ".*", :value ".*"}`)
 	returnAppend, _ := regexp.Compile(`{:process (\d+), :type :ok, :f :append, :key ".*", :value ".*"}`)
 
-	var events []Event = nil
+	var events []Event[kvInput, kvOutput] = nil
 
 	id := 0
 	procIdMap := make(map[int]int)
@@ -1317,19 +1317,19 @@ func parseKvLog(filename string) []Event {
 		case invokeGet.MatchString(line):
 			args := invokeGet.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
-			events = append(events, Event{proc, CallEvent, kvInput{op: 0, key: args[2]}, id})
+			events = append(events, Event[kvInput, kvOutput]{proc, CallEvent, kvInput{op: 0, key: args[2]}, id})
 			procIdMap[proc] = id
 			id++
 		case invokePut.MatchString(line):
 			args := invokePut.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
-			events = append(events, Event{proc, CallEvent, kvInput{op: 1, key: args[2], value: args[3]}, id})
+			events = append(events, Event[kvInput, kvOutput]{proc, CallEvent, kvInput{op: 1, key: args[2], value: args[3]}, id})
 			procIdMap[proc] = id
 			id++
 		case invokeAppend.MatchString(line):
 			args := invokeAppend.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
-			events = append(events, Event{proc, CallEvent, kvInput{op: 2, key: args[2], value: args[3]}, id})
+			events = append(events, Event[kvInput, kvOutput]{proc, CallEvent, kvInput{op: 2, key: args[2], value: args[3]}, id})
 			procIdMap[proc] = id
 			id++
 		case returnGet.MatchString(line):
@@ -1337,37 +1337,41 @@ func parseKvLog(filename string) []Event {
 			proc, _ := strconv.Atoi(args[1])
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
-			events = append(events, Event{proc, ReturnEvent, kvOutput{args[2]}, matchId})
+			events = append(events, Event[kvInput, kvOutput]{proc, ReturnEvent, kvOutput{args[2]}, matchId})
 		case returnPut.MatchString(line):
 			args := returnPut.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
-			events = append(events, Event{proc, ReturnEvent, kvOutput{}, matchId})
+			events = append(events, Event[kvInput, kvOutput]{proc, ReturnEvent, kvOutput{}, matchId})
 		case returnAppend.MatchString(line):
 			args := returnAppend.FindStringSubmatch(line)
 			proc, _ := strconv.Atoi(args[1])
 			matchId := procIdMap[proc]
 			delete(procIdMap, proc)
-			events = append(events, Event{proc, ReturnEvent, kvOutput{}, matchId})
+			events = append(events, Event[kvInput, kvOutput]{proc, ReturnEvent, kvOutput{}, matchId})
 		}
 	}
 
 	for proc, matchId := range procIdMap {
-		events = append(events, Event{proc, ReturnEvent, kvOutput{}, matchId})
+		events = append(events, Event[kvInput, kvOutput]{proc, ReturnEvent, kvOutput{}, matchId})
 	}
 
 	return events
 }
 
-func checkKv(t *testing.T, logName string, correct bool, partition bool) {
+func checkKvPartition(t *testing.T, logName string, correct bool) {
 	events := parseKvLog(fmt.Sprintf("test_data/kv/%s.txt", logName))
-	var model Model
-	if partition {
-		model = kvModel
-	} else {
-		model = kvNoPartitionModel
+	model := kvModel
+	res := CheckEvents(model, events)
+	if res != correct {
+		t.Fatalf("expected output %t, got output %t", correct, res)
 	}
+}
+
+func checkKvNoPartition(t *testing.T, logName string, correct bool) {
+	events := parseKvLog(fmt.Sprintf("test_data/kv/%s.txt", logName))
+	model := kvNoPartitionModel
 	res := CheckEvents(model, events)
 	if res != correct {
 		t.Fatalf("expected output %t, got output %t", correct, res)
@@ -1375,35 +1379,35 @@ func checkKv(t *testing.T, logName string, correct bool, partition bool) {
 }
 
 func TestKv1ClientOk(t *testing.T) {
-	checkKv(t, "c01-ok", true, true)
+	checkKvPartition(t, "c01-ok", true)
 }
 
 func TestKv1ClientBad(t *testing.T) {
-	checkKv(t, "c01-bad", false, true)
+	checkKvPartition(t, "c01-bad", false)
 }
 
 func TestKv10ClientsOk(t *testing.T) {
-	checkKv(t, "c10-ok", true, true)
+	checkKvPartition(t, "c10-ok", true)
 }
 
 func TestKv10ClientsBad(t *testing.T) {
-	checkKv(t, "c10-bad", false, true)
+	checkKvPartition(t, "c10-bad", false)
 }
 
 func TestKv50ClientsOk(t *testing.T) {
-	checkKv(t, "c50-ok", true, true)
+	checkKvPartition(t, "c50-ok", true)
 }
 
 func TestKv50ClientsBad(t *testing.T) {
-	checkKv(t, "c50-bad", false, true)
+	checkKvPartition(t, "c50-bad", false)
 }
 
 func TestKvNoPartition1ClientOk(t *testing.T) {
-	checkKv(t, "c01-ok", true, false)
+	checkKvNoPartition(t, "c01-ok", true)
 }
 
 func TestKvNoPartition1ClientBad(t *testing.T) {
-	checkKv(t, "c01-bad", false, false)
+	checkKvNoPartition(t, "c01-bad", false)
 }
 
 // takes about 90 seconds to run
@@ -1411,7 +1415,7 @@ func TestKvNoPartition10ClientsOk(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping testing in short mode")
 	}
-	checkKv(t, "c10-ok", true, false)
+	checkKvNoPartition(t, "c10-ok", true)
 }
 
 // takes about 60 seconds to run
@@ -1419,17 +1423,24 @@ func TestKvNoPartition10ClientsBad(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping testing in short mode")
 	}
-	checkKv(t, "c10-bad", false, false)
+	checkKvNoPartition(t, "c10-bad", false)
 }
 
-func benchKv(b *testing.B, logName string, correct bool, partition bool) {
+func benchKv(b *testing.B, logName string, correct bool) {
 	events := parseKvLog(fmt.Sprintf("test_data/kv/%s.txt", logName))
-	var model Model
-	if partition {
-		model = kvModel
-	} else {
-		model = kvNoPartitionModel
+	model := kvModel
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := CheckEvents(model, events)
+		if res != correct {
+			b.Fatalf("expected output %t, got output %t", correct, res)
+		}
 	}
+}
+
+func benchKvNoPartition(b *testing.B, logName string, correct bool) {
+	events := parseKvLog(fmt.Sprintf("test_data/kv/%s.txt", logName))
+	model := kvNoPartitionModel
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		res := CheckEvents(model, events)
@@ -1440,35 +1451,35 @@ func benchKv(b *testing.B, logName string, correct bool, partition bool) {
 }
 
 func BenchmarkKv1ClientOk(b *testing.B) {
-	benchKv(b, "c01-ok", true, true)
+	benchKv(b, "c01-ok", true)
 }
 
 func BenchmarkKv1ClientBad(b *testing.B) {
-	benchKv(b, "c01-bad", false, true)
+	benchKv(b, "c01-bad", false)
 }
 
 func BenchmarkKv10ClientsOk(b *testing.B) {
-	benchKv(b, "c10-ok", true, true)
+	benchKv(b, "c10-ok", true)
 }
 
 func BenchmarkKv10ClientsBad(b *testing.B) {
-	benchKv(b, "c10-bad", false, true)
+	benchKv(b, "c10-bad", false)
 }
 
 func BenchmarkKv50ClientsOk(b *testing.B) {
-	benchKv(b, "c50-ok", true, true)
+	benchKv(b, "c50-ok", true)
 }
 
 func BenchmarkKv50ClientsBad(b *testing.B) {
-	benchKv(b, "c50-bad", false, true)
+	benchKv(b, "c50-bad", false)
 }
 
 func BenchmarkKvNoPartition1ClientOk(b *testing.B) {
-	benchKv(b, "c01-ok", true, false)
+	benchKvNoPartition(b, "c01-ok", true)
 }
 
 func BenchmarkKvNoPartition1ClientBad(b *testing.B) {
-	benchKv(b, "c01-bad", false, false)
+	benchKvNoPartition(b, "c01-bad", false)
 }
 
 // takes about 90 seconds to run
@@ -1476,7 +1487,7 @@ func BenchmarkKvNoPartition10ClientsOk(b *testing.B) {
 	if testing.Short() {
 		b.Skip("skipping benchmark in short mode")
 	}
-	benchKv(b, "c10-ok", true, false)
+	benchKvNoPartition(b, "c10-ok", true)
 }
 
 // takes about 60 seconds to run
@@ -1484,7 +1495,7 @@ func BenchmarkKvNoPartition10ClientsBad(b *testing.B) {
 	if testing.Short() {
 		b.Skip("skipping benchmark in short mode")
 	}
-	benchKv(b, "c10-bad", false, false)
+	benchKvNoPartition(b, "c10-bad", false)
 }
 
 func TestSetModel(t *testing.T) {
@@ -1526,7 +1537,7 @@ func TestSetModel(t *testing.T) {
 		},
 	}
 
-	events := []Event{
+	events := []Event[setInput, setOutput]{
 		{0, CallEvent, setInput{true, 100}, 0},
 		{1, CallEvent, setInput{true, 0}, 1},
 		{2, CallEvent, setInput{false, 0}, 2},
@@ -1539,7 +1550,7 @@ func TestSetModel(t *testing.T) {
 		t.Fatal("expected operations to be linearizable")
 	}
 
-	events = []Event{
+	events = []Event[setInput, setOutput]{
 		{0, CallEvent, setInput{true, 100}, 0},
 		{1, CallEvent, setInput{true, 110}, 1},
 		{2, CallEvent, setInput{false, 0}, 2},
@@ -1552,7 +1563,7 @@ func TestSetModel(t *testing.T) {
 		t.Fatal("expected operations to be linearizable")
 	}
 
-	events = []Event{
+	events = []Event[setInput, setOutput]{
 		{0, CallEvent, setInput{true, 100}, 0},
 		{1, CallEvent, setInput{true, 110}, 1},
 		{2, CallEvent, setInput{false, 0}, 2},
@@ -1565,7 +1576,7 @@ func TestSetModel(t *testing.T) {
 		t.Fatal("expected operations to be linearizable")
 	}
 
-	events = []Event{
+	events = []Event[setInput, setOutput]{
 		{0, CallEvent, setInput{true, 100}, 0},
 		{1, CallEvent, setInput{true, 110}, 1},
 		{2, CallEvent, setInput{false, 0}, 2},

--- a/porcupine_test.go
+++ b/porcupine_test.go
@@ -29,7 +29,7 @@ func (i intState) String() string {
 type intSliceState []int
 
 func (i intSliceState) Clone() intSliceState {
-	ix := make([]int, len(i))
+	ix := make([]int, 0, len(i))
 	for _, i := range i {
 		ix = append(ix, i)
 	}

--- a/visualization.go
+++ b/visualization.go
@@ -30,7 +30,7 @@ type partitionVisualizationData struct {
 
 type visualizationData = []partitionVisualizationData
 
-func computeVisualizationData(model Model, info linearizationInfo) visualizationData {
+func computeVisualizationData[S State[S]](model Model[S], info linearizationInfo) visualizationData {
 	model = fillDefault(model)
 	data := make(visualizationData, len(info.history))
 	for partition := 0; partition < len(info.history); partition++ {
@@ -98,7 +98,7 @@ func computeVisualizationData(model Model, info linearizationInfo) visualization
 //
 // This function writes the visualization, an HTML file with embedded
 // JavaScript and data, to the given output.
-func Visualize(model Model, info linearizationInfo, output io.Writer) error {
+func Visualize[S State[S]](model Model[S], info linearizationInfo, output io.Writer) error {
 	data := computeVisualizationData(model, info)
 	jsonData, err := json.Marshal(data)
 	if err != nil {
@@ -113,7 +113,7 @@ func Visualize(model Model, info linearizationInfo, output io.Writer) error {
 
 // VisualizePath is a wrapper around [Visualize] to write the visualization to
 // a file path.
-func VisualizePath(model Model, info linearizationInfo, path string) error {
+func VisualizePath[S State[S]](model Model[S], info linearizationInfo, path string) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return err

--- a/visualization.go
+++ b/visualization.go
@@ -64,7 +64,7 @@ func computeVisualizationData[S State[S]](model Model[S], info linearizationInfo
 			state := model.Init()
 			for j, histId := range partial {
 				var ok bool
-				ok, state = model.Step(state, callValue[histId], returnValue[histId])
+				ok, state = model.Step(state.Clone(), callValue[histId], returnValue[histId])
 				if !ok {
 					panic("valid partial linearization returned non-ok result from model step")
 				}

--- a/visualization.go
+++ b/visualization.go
@@ -68,8 +68,7 @@ func computeVisualizationData[S State[S]](model Model[S], info linearizationInfo
 				if !ok {
 					panic("valid partial linearization returned non-ok result from model step")
 				}
-				stateDesc := model.DescribeState(state)
-				linearization[j] = linearizationStep{histId, stateDesc}
+				linearization[j] = linearizationStep{histId, state.String()}
 				if largestSize[histId] < len(partial) {
 					largestSize[histId] = len(partial)
 					largestIndex[histId] = i

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func visualizeTempFile[S State[S]](t *testing.T, model Model[S], info linearizationInfo) {
+func visualizeTempFile[S State[S], I any, O any](t *testing.T, model Model[S, I, O], info linearizationInfo) {
 	file, err := os.CreateTemp("", "*.html")
 	if err != nil {
 		t.Fatalf("failed to create temp file")

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -19,7 +19,7 @@ func visualizeTempFile[S State[S], I any, O any](t *testing.T, model Model[S, I,
 }
 
 func TestVisualizationMultipleLengths(t *testing.T) {
-	ops := []Operation{
+	ops := []Operation[kvInput, kvOutput]{
 		{0, kvInput{op: 0, key: "x"}, 0, kvOutput{"w"}, 100},
 		{1, kvInput{op: 1, key: "x", value: "y"}, 5, kvOutput{}, 10},
 		{2, kvInput{op: 1, key: "x", value: "z"}, 0, kvOutput{}, 10},
@@ -69,7 +69,7 @@ func TestVisualizationMultipleLengths(t *testing.T) {
 func TestRegisterModelReadme(t *testing.T) {
 	// basically the code from the README
 
-	events := []Event{
+	events := []Event[registerInput, int]{
 		// C0: Write(100)
 		{Kind: CallEvent, Value: registerInput{false, 100}, Id: 0, ClientId: 0},
 		// C1: Read()
@@ -93,7 +93,7 @@ func TestRegisterModelReadme(t *testing.T) {
 
 	visualizeTempFile(t, registerModel, info)
 
-	events = []Event{
+	events = []Event[registerInput, int]{
 		// C0: Write(200)
 		{Kind: CallEvent, Value: registerInput{false, 200}, Id: 0, ClientId: 0},
 		// C1: Read()

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -1,13 +1,13 @@
 package porcupine
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
 
-func visualizeTempFile(t *testing.T, model Model, info linearizationInfo) {
-	file, err := ioutil.TempFile("", "*.html")
+func visualizeTempFile[S State[S]](t *testing.T, model Model[S], info linearizationInfo) {
+	file, err := os.CreateTemp("", "*.html")
 	if err != nil {
 		t.Fatalf("failed to create temp file")
 	}


### PR DESCRIPTION
This is a breaking change in interface of Porcupine.

This set of commits does:
* move state to a generic interface, that must implement `Clone`, `String` and `Equals`
* make use of the above methods over the model defined function pointers
* use clone before calling step to avoid issues like in #11 
* use dedicated input/output types for the step function

Note that I'm still looking into refactoring the internal `entry`'s and `node`'value structure to a union type, this proves to be a little more difficult than anticipated - not sure this is currently even possible with two other generic types in Go. 
