### PR TITLE
Use generics instead of interface{}

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -60,7 +60,7 @@ func makeEntries(history []Operation) []entry {
 }
 
 type node struct {
-	value interface{}
+	value any
 	match *node // call if match is nil, otherwise return
 	id    int
 	next  *node
@@ -137,12 +137,12 @@ func makeLinkedEntries(entries []entry) *node {
 	return root
 }
 
-type cacheEntry struct {
+type cacheEntry[S State] struct {
 	linearized bitset
-	state      interface{}
+	state      S
 }
 
-func cacheContains(model Model, cache map[uint64][]cacheEntry, entry cacheEntry) bool {
+func cacheContains[S State, I Input, O Output](model Model[S, I, O], cache map[uint64][]cacheEntry[S], entry cacheEntry[S]) bool {
 	for _, elem := range cache[entry.linearized.hash()] {
 		if entry.linearized.equals(elem.linearized) && model.Equal(entry.state, elem.state) {
 			return true
@@ -151,9 +151,9 @@ func cacheContains(model Model, cache map[uint64][]cacheEntry, entry cacheEntry)
 	return false
 }
 
-type callsEntry struct {
+type callsEntry[S State] struct {
 	entry *node
-	state interface{}
+	state S
 }
 
 func lift(entry *node) {
@@ -176,12 +176,12 @@ func unlift(entry *node) {
 	entry.next.prev = entry
 }
 
-func checkSingle(model Model, history []entry, computePartial bool, kill *int32) (bool, []*[]int) {
+func checkSingle[S State, I Input, O Output](model Model[S, I, O], history []entry, computePartial bool, kill *int32) (bool, []*[]int) {
 	entry := makeLinkedEntries(history)
 	n := length(entry) / 2
 	linearized := newBitset(uint(n))
-	cache := make(map[uint64][]cacheEntry) // map from hash to cache entry
-	var calls []callsEntry
+	cache := make(map[uint64][]cacheEntry[S]) // map from hash to cache entry
+	var calls []callsEntry[S]
 	// longest linearizable prefix that includes the given entry
 	longest := make([]*[]int, n)
 
@@ -193,14 +193,14 @@ func checkSingle(model Model, history []entry, computePartial bool, kill *int32)
 		}
 		if entry.match != nil {
 			matching := entry.match // the return entry
-			ok, newState := model.Step(state, entry.value, matching.value)
+			ok, newState := model.Step(state, entry.value.(I), matching.value.(O))
 			if ok {
 				newLinearized := linearized.clone().set(uint(entry.id))
-				newCacheEntry := cacheEntry{newLinearized, newState}
+				newCacheEntry := cacheEntry[S]{newLinearized, newState}
 				if !cacheContains(model, cache, newCacheEntry) {
 					hash := newLinearized.hash()
 					cache[hash] = append(cache[hash], newCacheEntry)
-					calls = append(calls, callsEntry{entry, state})
+					calls = append(calls, callsEntry[S]{entry, state})
 					state = newState
 					linearized.set(uint(entry.id))
 					lift(entry)
@@ -252,7 +252,7 @@ func checkSingle(model Model, history []entry, computePartial bool, kill *int32)
 	return true, longest
 }
 
-func fillDefault(model Model) Model {
+func fillDefault[S State, I Input, O Output](model Model[S, I, O]) Model[S, I, O] {
 	if model.Partition == nil {
 		model.Partition = noPartition
 	}
@@ -260,18 +260,18 @@ func fillDefault(model Model) Model {
 		model.PartitionEvent = noPartitionEvent
 	}
 	if model.Equal == nil {
-		model.Equal = shallowEqual
+		model.Equal = shallowEqual[S]
 	}
 	if model.DescribeOperation == nil {
-		model.DescribeOperation = defaultDescribeOperation
+		model.DescribeOperation = defaultDescribeOperation[I, O]
 	}
 	if model.DescribeState == nil {
-		model.DescribeState = defaultDescribeState
+		model.DescribeState = defaultDescribeState[S]
 	}
 	return model
 }
 
-func checkParallel(model Model, history [][]entry, computeInfo bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkParallel[S State, I Input, O Output](model Model[S, I, O], history [][]entry, computeInfo bool, timeout time.Duration) (CheckResult, linearizationInfo) {
 	ok := true
 	timedOut := false
 	results := make(chan bool, len(history))
@@ -350,7 +350,7 @@ loop:
 	return result, info
 }
 
-func checkEvents(model Model, history []Event, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkEvents[S State, I Input, O Output](model Model[S, I, O], history []Event, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
 	model = fillDefault(model)
 	partitions := model.PartitionEvent(history)
 	l := make([][]entry, len(partitions))
@@ -360,7 +360,7 @@ func checkEvents(model Model, history []Event, verbose bool, timeout time.Durati
 	return checkParallel(model, l, verbose, timeout)
 }
 
-func checkOperations(model Model, history []Operation, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkOperations[S State, I Input, O Output](model Model[S, I, O], history []Operation, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
 	model = fillDefault(model)
 	partitions := model.Partition(history)
 	l := make([][]entry, len(partitions))

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/anishathalye/porcupine
 
-go 1.13
+go 1.19

--- a/porcupine.go
+++ b/porcupine.go
@@ -3,7 +3,7 @@ package porcupine
 import "time"
 
 // CheckOperations checks whether a history is linearizable.
-func CheckOperations(model Model, history []Operation) bool {
+func CheckOperations[S State, I Input, O Output](model Model[S, I, O], history []Operation) bool {
 	res, _ := checkOperations(model, history, false, 0)
 	return res == Ok
 }
@@ -12,7 +12,7 @@ func CheckOperations(model Model, history []Operation) bool {
 // timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckOperationsTimeout(model Model, history []Operation, timeout time.Duration) CheckResult {
+func CheckOperationsTimeout[S State, I Input, O Output](model Model[S, I, O], history []Operation, timeout time.Duration) CheckResult {
 	res, _ := checkOperations(model, history, false, timeout)
 	return res
 }
@@ -21,12 +21,12 @@ func CheckOperationsTimeout(model Model, history []Operation, timeout time.Durat
 // computing data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckOperationsVerbose(model Model, history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckOperationsVerbose[S State, I Input, O Output](model Model[S, I, O], history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkOperations(model, history, true, timeout)
 }
 
 // CheckEvents checks whether a history is linearizable.
-func CheckEvents(model Model, history []Event) bool {
+func CheckEvents[S State, I Input, O Output](model Model[S, I, O], history []Event) bool {
 	res, _ := checkEvents(model, history, false, 0)
 	return res == Ok
 }
@@ -34,7 +34,7 @@ func CheckEvents(model Model, history []Event) bool {
 // CheckEventsTimeout checks whether a history is linearizable, with a timeout.
 //
 // A timeout of 0 is interpreted as an unlimited timeout.
-func CheckEventsTimeout(model Model, history []Event, timeout time.Duration) CheckResult {
+func CheckEventsTimeout[S State, I Input, O Output](model Model[S, I, O], history []Event, timeout time.Duration) CheckResult {
 	res, _ := checkEvents(model, history, false, timeout)
 	return res
 }
@@ -43,6 +43,6 @@ func CheckEventsTimeout(model Model, history []Event, timeout time.Duration) Che
 // data that can be used to visualize the history and linearization.
 //
 // The returned linearizationInfo can be used with [Visualize].
-func CheckEventsVerbose(model Model, history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
+func CheckEventsVerbose[S State, I Input, O Output](model Model[S, I, O], history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
 	return checkEvents(model, history, true, timeout)
 }

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func visualizeTempFile(t *testing.T, model Model, info linearizationInfo) {
+func visualizeTempFile[S State, I Input, O Output](t *testing.T, model Model[S, I, O], info linearizationInfo) {
 	file, err := ioutil.TempFile("", "*.html")
 	if err != nil {
 		t.Fatalf("failed to create temp file")


### PR DESCRIPTION
First of all, thank you for the excellent tool.

I am actively using it now for checking internal systems. Describing models is very easy, but it is spoiled by using interface{} instead of specific types. I tried to fix it through generics.