### PR TITLE
fix: ioutil deprecation warning

### DIFF
--- a/visualization_test.go
+++ b/visualization_test.go
@@ -1,13 +1,13 @@
 package porcupine
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
 
 func visualizeTempFile(t *testing.T, model Model, info linearizationInfo) {
-	file, err := ioutil.TempFile("", "*.html")
+	file, err := os.CreateTemp("", "*.html")
 	if err != nil {
 		t.Fatalf("failed to create temp file")
 	}


### PR DESCRIPTION
`os.CreateTemp` is a drop-in replacement for the deprecated `ioutil.TempFile`. See https://pkg.go.dev/io/ioutil#TempFile.