### PR TITLE
Make LinearizationInfo struct public

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -21,7 +21,7 @@ type entry struct {
 	clientId int
 }
 
-type linearizationInfo struct {
+type LinearizationInfo struct {
 	history               [][]entry // for each partition, a list of entries
 	partialLinearizations [][][]int // for each partition, a set of histories (list of ids)
 }
@@ -271,7 +271,7 @@ func fillDefault(model Model) Model {
 	return model
 }
 
-func checkParallel(model Model, history [][]entry, computeInfo bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkParallel(model Model, history [][]entry, computeInfo bool, timeout time.Duration) (CheckResult, LinearizationInfo) {
 	ok := true
 	timedOut := false
 	results := make(chan bool, len(history))
@@ -308,7 +308,7 @@ loop:
 			break loop // if we time out, we might get a false positive
 		}
 	}
-	var info linearizationInfo
+	var info LinearizationInfo
 	if computeInfo {
 		// make sure we've waited for all goroutines to finish,
 		// otherwise we might race on access to longest[]
@@ -350,7 +350,7 @@ loop:
 	return result, info
 }
 
-func checkEvents(model Model, history []Event, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkEvents(model Model, history []Event, verbose bool, timeout time.Duration) (CheckResult, LinearizationInfo) {
 	model = fillDefault(model)
 	partitions := model.PartitionEvent(history)
 	l := make([][]entry, len(partitions))
@@ -360,7 +360,7 @@ func checkEvents(model Model, history []Event, verbose bool, timeout time.Durati
 	return checkParallel(model, l, verbose, timeout)
 }
 
-func checkOperations(model Model, history []Operation, verbose bool, timeout time.Duration) (CheckResult, linearizationInfo) {
+func checkOperations(model Model, history []Operation, verbose bool, timeout time.Duration) (CheckResult, LinearizationInfo) {
 	model = fillDefault(model)
 	partitions := model.Partition(history)
 	l := make([][]entry, len(partitions))

--- a/porcupine.go
+++ b/porcupine.go
@@ -20,8 +20,8 @@ func CheckOperationsTimeout(model Model, history []Operation, timeout time.Durat
 // CheckOperationsVerbose checks whether a history is linearizable while
 // computing data that can be used to visualize the history and linearization.
 //
-// The returned linearizationInfo can be used with [Visualize].
-func CheckOperationsVerbose(model Model, history []Operation, timeout time.Duration) (CheckResult, linearizationInfo) {
+// The returned LinearizationInfo can be used with [Visualize].
+func CheckOperationsVerbose(model Model, history []Operation, timeout time.Duration) (CheckResult, LinearizationInfo) {
 	return checkOperations(model, history, true, timeout)
 }
 
@@ -42,7 +42,7 @@ func CheckEventsTimeout(model Model, history []Event, timeout time.Duration) Che
 // CheckEventsVerbose checks whether a history is linearizable while computing
 // data that can be used to visualize the history and linearization.
 //
-// The returned linearizationInfo can be used with [Visualize].
-func CheckEventsVerbose(model Model, history []Event, timeout time.Duration) (CheckResult, linearizationInfo) {
+// The returned LinearizationInfo can be used with [Visualize].
+func CheckEventsVerbose(model Model, history []Event, timeout time.Duration) (CheckResult, LinearizationInfo) {
 	return checkEvents(model, history, true, timeout)
 }

--- a/visualization.go
+++ b/visualization.go
@@ -31,7 +31,7 @@ type partitionVisualizationData struct {
 
 type visualizationData = []partitionVisualizationData
 
-func computeVisualizationData(model Model, info linearizationInfo) visualizationData {
+func computeVisualizationData(model Model, info LinearizationInfo) visualizationData {
 	model = fillDefault(model)
 	data := make(visualizationData, len(info.history))
 	for partition := 0; partition < len(info.history); partition++ {
@@ -94,12 +94,12 @@ func computeVisualizationData(model Model, info linearizationInfo) visualization
 // the history. If the history is not linearizable, the visualization shows
 // partial linearizations and illegal linearization points.
 //
-// To get the linearizationInfo that this function requires, you can use
+// To get the LinearizationInfo that this function requires, you can use
 // [CheckOperationsVerbose] / [CheckEventsVerbose].
 //
 // This function writes the visualization, an HTML file with embedded
 // JavaScript and data, to the given output.
-func Visualize(model Model, info linearizationInfo, output io.Writer) error {
+func Visualize(model Model, info LinearizationInfo, output io.Writer) error {
 	data := computeVisualizationData(model, info)
 	jsonData, err := json.Marshal(data)
 	if err != nil {
@@ -118,7 +118,7 @@ func Visualize(model Model, info linearizationInfo, output io.Writer) error {
 
 // VisualizePath is a wrapper around [Visualize] to write the visualization to
 // a file path.
-func VisualizePath(model Model, info linearizationInfo, path string) error {
+func VisualizePath(model Model, info LinearizationInfo, path string) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return err

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func visualizeTempFile(t *testing.T, model Model, info linearizationInfo) {
+func visualizeTempFile(t *testing.T, model Model, info LinearizationInfo) {
 	file, err := os.CreateTemp("", "*.html")
 	if err != nil {
 		t.Fatalf("failed to create temp file")


### PR DESCRIPTION
I don't see any reason to keep linearizationInfo unexported.

It's not a good practice https://github.com/golang/lint/issues/210 and it causes award code. For example https://github.com/etcd-io/etcd/blob/8d3abed266f9b8942a357e7d72ca80e18f4b7172/tests/robustness/validate/operations.go#L45-L52 where type needs to be wrapped into a function to be passed up the call stack. 