### PR TITLE
Revert to prev staticcheck pkg pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Staticcheck
-        run: "staticcheck -f stylish *.go"
+        run: "staticcheck -f stylish ./..."


### PR DESCRIPTION
According to the [staticcheck cli docs](https://staticcheck.dev/docs/getting-started/#running-staticcheck), the pkg pattern is parsed just like in normal Go commands. So `./...` is the right way to test all pkgs recursively, including test files.

As to why this wasn't catching the ioutil deprecation warning (see [previous discussion](https://github.com/anishathalye/porcupine/pull/15#issuecomment-1910449316)), I figured it out! `ioutil` was only deprecated in Go 1.19. Since your `go.mod` version is 1.16, staticcheck doesn't flag it. When you switched to `*.go`, it treated each Go file independently, which uses the system (not `go.mod`) Go version but also 1) might trigger false positives that lack pkg context to resolve and 2) doesn't recursively check things. 

I think it's better to switch back to `./...`, and if you want to catch those deprecation issues, bump the go version, at the risk of making problems for upstream deps.