### PR TITLE
Specify charset in visualization to support Unicode

### DIFF
--- a/visualization/index.html
+++ b/visualization/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Porcupine</title>
     <style>
       %s


### PR DESCRIPTION
Browsers try to divine the character encoding used in an HTML document on a bunch of heuristics, but it appears the default is ISO-8859-1, which mangles unicode (UTF-8) strings that are typical in Go. This patch adds the charset meta tag.