### PR TITLE
Add metadata to the operation visualization

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -19,6 +19,7 @@ type entry struct {
 	id       int
 	time     int64
 	clientId int
+	metadata interface{}
 }
 
 type LinearizationInfo struct {
@@ -74,6 +75,7 @@ func (li *LinearizationInfo) PartialLinearizationsOperations() [][][]Operation {
 				Call:     call.time,
 				Output:   ret.value,
 				Return:   ret.time,
+				Metadata: call.metadata,
 			}
 		}
 
@@ -121,9 +123,9 @@ func makeEntries(history []Operation) []entry {
 	id := 0
 	for _, elem := range history {
 		entries = append(entries, entry{
-			callEntry, elem.Input, id, elem.Call, elem.ClientId})
+			callEntry, elem.Input, id, elem.Call, elem.ClientId, elem.Metadata})
 		entries = append(entries, entry{
-			returnEntry, elem.Output, id, elem.Return, elem.ClientId})
+			returnEntry, elem.Output, id, elem.Return, elem.ClientId, elem.Metadata})
 		id++
 	}
 	sort.Sort(byTime(entries))
@@ -184,7 +186,7 @@ func convertEntries(events []Event) []entry {
 			kind = returnEntry
 		}
 		// use index as "time"
-		entries = append(entries, entry{kind, elem.Value, elem.Id, int64(i), elem.ClientId})
+		entries = append(entries, entry{kind, elem.Value, elem.Id, int64(i), elem.ClientId, nil})
 	}
 	return entries
 }
@@ -338,6 +340,9 @@ func fillDefault(model Model) Model {
 	}
 	if model.DescribeState == nil {
 		model.DescribeState = defaultDescribeState
+	}
+	if model.DescribeOperationMetadata == nil {
+		model.DescribeOperationMetadata = defaultDescribeOperationMetadata
 	}
 	return model
 }

--- a/checker.go
+++ b/checker.go
@@ -168,9 +168,9 @@ func renumber(events []Event) []Event {
 	id := 0
 	for _, v := range events {
 		if r, ok := m[v.Id]; ok {
-			e = append(e, Event{ClientId: v.ClientId, Kind: v.Kind, Value: v.Value, Id: r})
+			e = append(e, Event{ClientId: v.ClientId, Kind: v.Kind, Value: v.Value, Id: r, Metadata: v.Metadata})
 		} else {
-			e = append(e, Event{ClientId: v.ClientId, Kind: v.Kind, Value: v.Value, Id: id})
+			e = append(e, Event{ClientId: v.ClientId, Kind: v.Kind, Value: v.Value, Id: id, Metadata: v.Metadata})
 			m[v.Id] = id
 			id++
 		}
@@ -182,11 +182,15 @@ func convertEntries(events []Event) []entry {
 	var entries []entry
 	for i, elem := range events {
 		kind := callEntry
+		var metadata interface{}
 		if elem.Kind == ReturnEvent {
 			kind = returnEntry
+			// ignore metadata on return events (only call events carry metadata)
+		} else {
+			metadata = elem.Metadata
 		}
 		// use index as "time"
-		entries = append(entries, entry{kind, elem.Value, elem.Id, int64(i), elem.ClientId, nil})
+		entries = append(entries, entry{kind, elem.Value, elem.Id, int64(i), elem.ClientId, metadata})
 	}
 	return entries
 }

--- a/model.go
+++ b/model.go
@@ -68,6 +68,10 @@ type Event struct {
 	Kind     EventKind
 	Value    interface{}
 	Id       int
+	// Metadata contains arbitrary metadata associated with the operation.
+	// It is not used for linearizability checking but can be used for visualization.
+	// Only set this on CallEvent; it is ignored for ReturnEvent.
+	Metadata interface{}
 	_        struct{} // disallow positional literals, for extensibility
 }
 

--- a/model.go
+++ b/model.go
@@ -20,7 +20,10 @@ type Operation struct {
 	Input    interface{}
 	Call     int64 // invocation timestamp
 	Output   interface{}
-	Return   int64    // response timestamp
+	Return   int64 // response timestamp
+	// Metadata contains arbitrary metadata associated with the operation.
+	// It is not used for linearizability checking but can be used for visualization.
+	Metadata interface{}
 	_        struct{} // disallow positional literals, for extensibility
 }
 
@@ -114,7 +117,10 @@ type Model struct {
 	// example, "{'x' -> 'y', 'z' -> 'w'}". Can be omitted if you're not
 	// producing visualizations.
 	DescribeState func(state interface{}) string
-	_             struct{} // disallow positional literals, for extensibility
+	// For visualization purposes, describe metadata as a string. Can be
+	// omitted if you're not producing visualizations.
+	DescribeOperationMetadata func(info interface{}) string
+	_                         struct{} // disallow positional literals, for extensibility
 }
 
 // A NondeterministicModel is a nondeterministic sequential specification of a
@@ -153,7 +159,10 @@ type NondeterministicModel struct {
 	// example, "{'x' -> 'y', 'z' -> 'w'}". Can be omitted if you're not
 	// producing visualizations.
 	DescribeState func(state interface{}) string
-	_             struct{} // disallow positional literals, for extensibility
+	// For visualization purposes, describe metadata as a string. Can be
+	// omitted if you're not producing visualizations.
+	DescribeOperationMetadata func(info interface{}) string
+	_                         struct{} // disallow positional literals, for extensibility
 }
 
 func merge(states []interface{}, eq func(state1, state2 interface{}) bool) []interface{} {
@@ -194,6 +203,10 @@ func (nm *NondeterministicModel) ToModel() Model {
 	describeState := nm.DescribeState
 	if describeState == nil {
 		describeState = defaultDescribeState
+	}
+	describeOperationMetadata := nm.DescribeOperationMetadata
+	if describeOperationMetadata == nil {
+		describeOperationMetadata = defaultDescribeOperationMetadata
 	}
 	return Model{
 		Partition:      nm.Partition,
@@ -242,6 +255,7 @@ func (nm *NondeterministicModel) ToModel() Model {
 			}
 			return fmt.Sprintf("{%s}", strings.Join(descriptions, ", "))
 		},
+		DescribeOperationMetadata: describeOperationMetadata,
 	}
 }
 
@@ -273,6 +287,15 @@ func defaultDescribeOperation(input interface{}, output interface{}) string {
 // renders the state using the "%v" format specifier.
 func defaultDescribeState(state interface{}) string {
 	return fmt.Sprintf("%v", state)
+}
+
+// defaultDescribeOperationMetadata is a fallback to convert metadata to a
+// string. It renders the metadata using the "%v" format specifier.
+func defaultDescribeOperationMetadata(info interface{}) string {
+	if info == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", info)
 }
 
 // A CheckResult is the result of a linearizability check.

--- a/porcupine_test.go
+++ b/porcupine_test.go
@@ -50,9 +50,9 @@ func TestRegisterModel(t *testing.T) {
 	// section VII
 
 	ops := []Operation{
-		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60},
+		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75, Metadata: nil},
+		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60, Metadata: nil},
 	}
 	res := CheckOperations(registerModel, ops)
 	if res != true {
@@ -74,9 +74,9 @@ func TestRegisterModel(t *testing.T) {
 	}
 
 	ops = []Operation{
-		{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 30},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90},
+		{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 30, Metadata: nil},
+		{ClientId: 2, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90, Metadata: nil},
 	}
 	res = CheckOperations(registerModel, ops)
 	if res != false {
@@ -100,10 +100,10 @@ func TestRegisterModel(t *testing.T) {
 
 func TestZeroDuration(t *testing.T) {
 	ops := []Operation{
-		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30},
-		{ClientId: 3, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30},
+		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75, Metadata: nil},
+		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30, Metadata: nil},
+		{ClientId: 3, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30, Metadata: nil},
 	}
 	res, info := CheckOperationsVerbose(registerModel, ops, 0)
 	if res != Ok {
@@ -113,10 +113,10 @@ func TestZeroDuration(t *testing.T) {
 	visualizeTempFile(t, registerModel, info)
 
 	ops = []Operation{
-		{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10},
-		{ClientId: 3, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90},
+		{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10, Metadata: nil},
+		{ClientId: 2, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10, Metadata: nil},
+		{ClientId: 3, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90, Metadata: nil},
 	}
 	res, _ = CheckOperationsVerbose(registerModel, ops, 0)
 	if res != Illegal {
@@ -1701,5 +1701,48 @@ func TestCheckNoPartitions(t *testing.T) {
 	res, _ := CheckOperationsVerbose(kvModel, ops, 0)
 	if res != Ok {
 		t.Fatalf("expected output %v, got output %v", Ok, res)
+	}
+}
+
+func TestRegisterModelMetadata(t *testing.T) {
+	// similar to TestRegisterModel but with metadata
+	ops := []Operation{
+		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100, Metadata: "meta1"},
+		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75, Metadata: "meta2"},
+		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60, Metadata: "meta3"},
+	}
+	res, info := CheckOperationsVerbose(registerModel, ops, 0)
+	if res != Ok {
+		t.Fatal("expected operations to be linearizable")
+	}
+
+	// Verify metadata propagation to internal history
+	// We expect 3 operations * 2 entries (call+return) = 6 entries
+	if len(info.history) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(info.history))
+	}
+	entries := info.history[0]
+	if len(entries) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(entries))
+	}
+
+	// We can map IDs to metadata to verify.
+	expectedMeta := map[int]string{
+		0: "meta1",
+		1: "meta2",
+		2: "meta3",
+	}
+
+	for _, e := range entries {
+		if e.metadata == "" {
+			// convertEntries in checker.go (if used via checkEvents) sets empty string,
+			// but CheckOperationsVerbose uses makeEntries which copies it.
+			// ops above has metadata.
+			t.Errorf("entry %d (id %d) metadata is empty", e.time, e.id)
+			continue
+		}
+		if expectedMeta[e.id] != e.metadata {
+			t.Errorf("entry %d (id %d) expected metadata %s, got %s", e.time, e.id, expectedMeta[e.id], e.metadata)
+		}
 	}
 }

--- a/visualization.go
+++ b/visualization.go
@@ -16,6 +16,7 @@ type historyElement struct {
 	End           int
 	OriginalEnd   string
 	Description   string
+	Metadata      string
 }
 
 type annotation struct {
@@ -152,6 +153,7 @@ func computeVisualizationData(model Model, info LinearizationInfo) visualization
 				history[elem.id].Start = timeMap[elem.time]
 				history[elem.id].OriginalStart = fmt.Sprintf("%d", elem.time)
 				callValue[elem.id] = elem.value
+				history[elem.id].Metadata = model.DescribeOperationMetadata(elem.metadata)
 			case returnEntry:
 				history[elem.id].End = timeMap[elem.time]
 				history[elem.id].OriginalEnd = fmt.Sprintf("%d", elem.time)

--- a/visualization/index.js
+++ b/visualization/index.js
@@ -701,18 +701,28 @@ function render(data) {
       const callTime = allData[partition].History[index].OriginalStart
       const returnTime = allData[partition].History[index].OriginalEnd
 
+      let metadata = ''
+      if (partition < coreHistory.length) {
+        const m = allData[partition].History[index].Metadata
+        if (m !== '') {
+          metadata = m + '<br><br>'
+        }
+      }
+
       if (partition >= coreHistory.length) {
         // Annotation
         const details = annotations[index].Details
         tooltip.innerHTML = details.length === 0 ? '&langle;no details&rangle;' : details
       } else if (selected && sPartition !== partition) {
         tooltip.innerHTML =
-          'Not part of selected partition.' + formatCallReturn(callTime, returnTime)
+          metadata + 'Not part of selected partition.' + formatCallReturn(callTime, returnTime)
       } else if (maxIndex === null) {
         tooltip.innerHTML =
+          metadata +
           (selected
             ? 'Selected element is not part of any partial linearization.'
-            : 'Not part of any partial linearization.') + formatCallReturn(callTime, returnTime)
+            : 'Not part of any partial linearization.') +
+          formatCallReturn(callTime, returnTime)
       } else {
         const lin = coreHistory[partition].PartialLinearizations[maxIndex]
         let previous = null
@@ -727,11 +737,12 @@ function render(data) {
           }
         }
 
-        let message = ''
+        let message = metadata
+
         if (found) {
           // Part of linearization
           if (previous !== null) {
-            message =
+            message +=
               '<strong>Previous state:</strong><br>' + previous.StateDescription + '<br><br>'
           }
 
@@ -741,14 +752,14 @@ function render(data) {
             formatCallReturn(callTime, returnTime)
         } else if (illegalLast[partition][maxIndex].has(index)) {
           // Illegal next one
-          message =
+          message +=
             '<strong>Previous state:</strong><br>' +
             lin.at(-1).StateDescription +
             '<br><br><strong>New state:</strong><br>&langle;invalid op&rangle;' +
             formatCallReturn(callTime, returnTime)
         } else {
           // Not part of this one
-          message =
+          message +=
             "Not part of selected element's partial linearization." +
             formatCallReturn(callTime, returnTime)
         }

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -405,3 +405,58 @@ func TestVisualizationMetadataAlwaysVisible(t *testing.T) {
 		t.Errorf("expected HTML to contain meta_not_linearizable")
 	}
 }
+
+func TestVisualizationEventMetadata(t *testing.T) {
+	model := registerModel
+	model.DescribeOperationMetadata = func(info interface{}) string {
+		if info == nil {
+			return ""
+		}
+		return fmt.Sprintf("event-meta: %v", info)
+	}
+
+	events := []Event{
+		// C0: Write(100) with metadata on CallEvent
+		{Kind: CallEvent, Value: registerInput{false, 100}, Id: 0, ClientId: 0, Metadata: "write-call-meta"},
+		// C1: Read() with metadata on CallEvent
+		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1, Metadata: "read-call-meta"},
+		// C1: Completed Read -> 100 (metadata on ReturnEvent should be ignored)
+		{Kind: ReturnEvent, Value: 100, Id: 1, ClientId: 1, Metadata: "read-return-meta-SHOULD-BE-IGNORED"},
+		// C0: Completed Write (metadata on ReturnEvent should be ignored)
+		{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0, Metadata: "write-return-meta-SHOULD-BE-IGNORED"},
+	}
+
+	res, info := CheckEventsVerbose(model, events, 0)
+	if res != Ok {
+		t.Fatal("expected operations to be linearizable")
+	}
+
+	file, err := os.CreateTemp("", "porcupine_test_event_metadata_*.html")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := Visualize(model, info, file); err != nil {
+		t.Fatalf("Visualize failed: %v", err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("failed to read generated HTML: %v", err)
+	}
+
+	s := string(content)
+	// CallEvent metadata should be present
+	if !strings.Contains(s, "event-meta: write-call-meta") {
+		t.Errorf("expected HTML to contain 'event-meta: write-call-meta'")
+	}
+	if !strings.Contains(s, "event-meta: read-call-meta") {
+		t.Errorf("expected HTML to contain 'event-meta: read-call-meta'")
+	}
+	// ReturnEvent metadata should be ignored
+	if strings.Contains(s, "SHOULD-BE-IGNORED") {
+		t.Errorf("expected HTML to NOT contain ReturnEvent metadata, but found 'SHOULD-BE-IGNORED'")
+	}
+}

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -1,6 +1,7 @@
 package porcupine
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -21,15 +22,15 @@ func visualizeTempFile(t *testing.T, model Model, info LinearizationInfo) {
 
 func TestVisualizationMultipleLengths(t *testing.T) {
 	ops := []Operation{
-		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100},
-		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 5, Output: kvOutput{}, Return: 10},
-		{ClientId: 2, Input: kvInput{op: 1, key: "x", value: "z"}, Call: 0, Output: kvOutput{}, Return: 10},
-		{ClientId: 1, Input: kvInput{op: 0, key: "x"}, Call: 20, Output: kvOutput{"y"}, Return: 30},
-		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "w"}, Call: 35, Output: kvOutput{}, Return: 45},
-		{ClientId: 5, Input: kvInput{op: 0, key: "x"}, Call: 25, Output: kvOutput{"z"}, Return: 35},
-		{ClientId: 3, Input: kvInput{op: 0, key: "x"}, Call: 30, Output: kvOutput{"y"}, Return: 40},
-		{ClientId: 4, Input: kvInput{op: 0, key: "y"}, Call: 50, Output: kvOutput{"a"}, Return: 90},
-		{ClientId: 2, Input: kvInput{op: 1, key: "y", value: "a"}, Call: 55, Output: kvOutput{}, Return: 85},
+		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 5, Output: kvOutput{}, Return: 10, Metadata: nil},
+		{ClientId: 2, Input: kvInput{op: 1, key: "x", value: "z"}, Call: 0, Output: kvOutput{}, Return: 10, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 0, key: "x"}, Call: 20, Output: kvOutput{"y"}, Return: 30, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "w"}, Call: 35, Output: kvOutput{}, Return: 45, Metadata: nil},
+		{ClientId: 5, Input: kvInput{op: 0, key: "x"}, Call: 25, Output: kvOutput{"z"}, Return: 35, Metadata: nil},
+		{ClientId: 3, Input: kvInput{op: 0, key: "x"}, Call: 30, Output: kvOutput{"y"}, Return: 40, Metadata: nil},
+		{ClientId: 4, Input: kvInput{op: 0, key: "y"}, Call: 50, Output: kvOutput{"a"}, Return: 90, Metadata: nil},
+		{ClientId: 2, Input: kvInput{op: 1, key: "y", value: "a"}, Call: 55, Output: kvOutput{}, Return: 85, Metadata: nil},
 	}
 	res, info := CheckOperationsVerbose(kvModel, ops, 0)
 	if res != Illegal {
@@ -132,15 +133,15 @@ func TestVisualizationLarge(t *testing.T) {
 func TestVisualizationAnnotations(t *testing.T) {
 	// base set of operations same as TestVisualizationMultipleLengths
 	ops := []Operation{
-		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100},
-		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 5, Output: kvOutput{}, Return: 10},
-		{ClientId: 2, Input: kvInput{op: 1, key: "x", value: "z"}, Call: 0, Output: kvOutput{}, Return: 10},
-		{ClientId: 1, Input: kvInput{op: 0, key: "x"}, Call: 20, Output: kvOutput{"y"}, Return: 30},
-		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "w"}, Call: 35, Output: kvOutput{}, Return: 45},
-		{ClientId: 5, Input: kvInput{op: 0, key: "x"}, Call: 25, Output: kvOutput{"z"}, Return: 35},
-		{ClientId: 3, Input: kvInput{op: 0, key: "x"}, Call: 30, Output: kvOutput{"y"}, Return: 40},
-		{ClientId: 4, Input: kvInput{op: 0, key: "y"}, Call: 50, Output: kvOutput{"a"}, Return: 90},
-		{ClientId: 2, Input: kvInput{op: 1, key: "y", value: "a"}, Call: 55, Output: kvOutput{}, Return: 85},
+		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 5, Output: kvOutput{}, Return: 10, Metadata: nil},
+		{ClientId: 2, Input: kvInput{op: 1, key: "x", value: "z"}, Call: 0, Output: kvOutput{}, Return: 10, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 0, key: "x"}, Call: 20, Output: kvOutput{"y"}, Return: 30, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "w"}, Call: 35, Output: kvOutput{}, Return: 45, Metadata: nil},
+		{ClientId: 5, Input: kvInput{op: 0, key: "x"}, Call: 25, Output: kvOutput{"z"}, Return: 35, Metadata: nil},
+		{ClientId: 3, Input: kvInput{op: 0, key: "x"}, Call: 30, Output: kvOutput{"y"}, Return: 40, Metadata: nil},
+		{ClientId: 4, Input: kvInput{op: 0, key: "y"}, Call: 50, Output: kvOutput{"a"}, Return: 90, Metadata: nil},
+		{ClientId: 2, Input: kvInput{op: 1, key: "y", value: "a"}, Call: 55, Output: kvOutput{}, Return: 85, Metadata: nil},
 	}
 	res, info := CheckOperationsVerbose(kvModel, ops, 0)
 	annotations := []Annotation{
@@ -167,8 +168,8 @@ func TestVisualizationAnnotations(t *testing.T) {
 
 func TestVisualizePointInTimeAnnotationsEnd(t *testing.T) {
 	ops := []Operation{
-		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100},
-		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 50, Output: kvOutput{}, Return: 60},
+		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 50, Output: kvOutput{}, Return: 60, Metadata: nil},
 	}
 	res, info := CheckOperationsVerbose(kvModel, ops, 0)
 	if res != Illegal {
@@ -187,8 +188,8 @@ func TestVisualizePointInTimeAnnotationsEnd(t *testing.T) {
 
 func TestVisualizeMatchingStartEnd(t *testing.T) {
 	ops := []Operation{
-		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 50},
-		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 50, Output: kvOutput{}, Return: 80},
+		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 50, Metadata: nil},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 50, Output: kvOutput{}, Return: 80, Metadata: nil},
 	}
 	res, info := CheckOperationsVerbose(kvModel, ops, 0)
 	if res != Illegal {
@@ -225,7 +226,7 @@ func TestVisualizationCallAndReturnTime(t *testing.T) {
 		{
 			name: "LinearizableContent",
 			ops: []Operation{
-				{ClientId: 0, Input: kvInput{op: 1, key: "x", value: "a"}, Call: 0, Output: kvOutput{}, Return: 100},
+				{ClientId: 0, Input: kvInput{op: 1, key: "x", value: "a"}, Call: 0, Output: kvOutput{}, Return: 100, Metadata: ""},
 			},
 			expectedRes:    Ok, // CheckOperationsVerbose returns Ok for linearizable
 			expectedStarts: []string{`"OriginalStart":"0"`},
@@ -290,5 +291,117 @@ func TestVisualizationCallAndReturnTime(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestVisualizationStringMetadata(t *testing.T) {
+	model := kvModel
+	model.DescribeOperationMetadata = func(info interface{}) string {
+		return fmt.Sprintf("custom: %v", info)
+	}
+
+	ops := []Operation{
+		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100, Metadata: "meta1"},
+	}
+	_, info := CheckOperationsVerbose(model, ops, 0)
+
+	file, err := os.CreateTemp("", "porcupine_test_custom_metadata_*.html")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := Visualize(model, info, file); err != nil {
+		t.Fatalf("Visualize failed: %v", err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("failed to read generated HTML: %v", err)
+	}
+
+	if !strings.Contains(string(content), "custom: meta1") {
+		t.Errorf("expected HTML to contain custom metadata 'custom: meta1'")
+	}
+}
+
+type customMetadata struct {
+	ID   int
+	Info string
+}
+
+func TestVisualizationStructMetadata(t *testing.T) {
+	ops := []Operation{
+		{ClientId: 0, Input: kvInput{op: 0, key: "x"}, Call: 0, Output: kvOutput{"w"}, Return: 100, Metadata: customMetadata{1, "meta1"}},
+		{ClientId: 1, Input: kvInput{op: 1, key: "x", value: "y"}, Call: 5, Output: kvOutput{}, Return: 10, Metadata: customMetadata{2, "meta2"}},
+	}
+
+	// Define a model that handles custom metadata
+	model := kvModel
+	model.DescribeOperationMetadata = func(info interface{}) string {
+		if m, ok := info.(customMetadata); ok {
+			return fmt.Sprintf("ID:%d, Info:%s", m.ID, m.Info)
+		}
+		return fmt.Sprintf("%v", info)
+	}
+
+	_, info := CheckOperationsVerbose(model, ops, 0)
+
+	file, err := os.CreateTemp("", "porcupine_test_custom_metadata_*.html")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := Visualize(model, info, file); err != nil {
+		t.Fatalf("Visualize failed: %v", err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("failed to read generated HTML: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "ID:1, Info:meta1") {
+		t.Errorf("expected HTML to contain ID:1, Info:meta1")
+	}
+	if !strings.Contains(s, "ID:2, Info:meta2") {
+		t.Errorf("expected HTML to contain ID:2, Info:meta2")
+	}
+}
+
+func TestVisualizationMetadataAlwaysVisible(t *testing.T) {
+	ops := []Operation{
+		{ClientId: 0, Input: kvInput{op: 1, key: "x", value: "val"}, Call: 0, Output: kvOutput{}, Return: 100, Metadata: "meta_linearizable"},
+		{ClientId: 1, Input: kvInput{op: 0, key: "x"}, Call: 5, Output: kvOutput{"invalid"}, Return: 10, Metadata: "meta_not_linearizable"},
+	}
+
+	_, info := CheckOperationsVerbose(kvModel, ops, 0)
+
+	file, err := os.CreateTemp("", "porcupine_test_metadata_visible_*.html")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := Visualize(kvModel, info, file); err != nil {
+		t.Fatalf("Visualize failed: %v", err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("failed to read generated HTML: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "meta_linearizable") {
+		t.Errorf("expected HTML to contain meta_linearizable")
+	}
+	if !strings.Contains(s, "meta_not_linearizable") {
+		t.Errorf("expected HTML to contain meta_not_linearizable")
 	}
 }


### PR DESCRIPTION
Enable the tooltip to be populated with arbitrary metadata of the type string.

Address the second part of the issue in https://github.com/anishathalye/porcupine/issues/37.

<img width="673" height="278" alt="Screenshot 2025-12-08 at 4 38 00 PM" src="https://github.com/user-attachments/assets/03b16da3-c5ff-4474-b635-77bd1276f2e4" />

