### PR TITLE
Add `StepContext` to allow timeout to be propagated and keeping `Step` for backward compatibility

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -1,6 +1,7 @@
 package porcupine
 
 import (
+	"context"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -254,7 +255,14 @@ func unlift(entry *node) {
 	entry.next.prev = entry
 }
 
-func checkSingle(model Model, history []entry, computePartial bool, kill *int32) (bool, []*[]int) {
+func modelStep(ctx context.Context, model Model, state interface{}, input interface{}, output interface{}) (bool, interface{}) {
+	if model.StepContext != nil {
+		return model.StepContext(ctx, state, input, output)
+	}
+	return model.Step(state, input, output)
+}
+
+func checkSingle(ctx context.Context, model Model, history []entry, computePartial bool, kill *int32) (bool, []*[]int) {
 	entry := makeLinkedEntries(history)
 	n := length(entry) / 2
 	linearized := newBitset(uint(n))
@@ -266,12 +274,15 @@ func checkSingle(model Model, history []entry, computePartial bool, kill *int32)
 	state := model.Init()
 	headEntry := insertBefore(&node{value: nil, match: nil, id: -1}, entry)
 	for headEntry.next != nil {
-		if atomic.LoadInt32(kill) != 0 {
+		if atomic.LoadInt32(kill) != 0 || ctx.Err() != nil {
 			return false, longest
 		}
 		if entry.match != nil {
 			matching := entry.match // the return entry
-			ok, newState := model.Step(state, entry.value, matching.value)
+			ok, newState := modelStep(ctx, model, state, entry.value, matching.value)
+			if ctx.Err() != nil {
+				return false, longest
+			}
 			if ok {
 				newLinearized := linearized.clone().set(uint(entry.id))
 				newCacheEntry := cacheEntry{newLinearized, newState}
@@ -358,12 +369,14 @@ func checkParallel(model Model, history [][]entry, computeInfo bool, timeout tim
 	}
 	ok := true
 	timedOut := false
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	results := make(chan bool, len(history))
 	longest := make([][]*[]int, len(history))
 	kill := int32(0)
 	for i, subhistory := range history {
 		go func(i int, subhistory []entry) {
-			ok, l := checkSingle(model, subhistory, computeInfo, &kill)
+			ok, l := checkSingle(ctx, model, subhistory, computeInfo, &kill)
 			longest[i] = l
 			results <- ok
 		}(i, subhistory)
@@ -381,6 +394,7 @@ loop:
 			ok = ok && result
 			if !ok && !computeInfo {
 				atomic.StoreInt32(&kill, 1)
+				cancel()
 				break loop
 			}
 			if count >= len(history) {
@@ -389,6 +403,7 @@ loop:
 		case <-timeoutChan:
 			timedOut = true
 			atomic.StoreInt32(&kill, 1)
+			cancel()
 			break loop // if we time out, we might get a false positive
 		}
 	}

--- a/model.go
+++ b/model.go
@@ -1,6 +1,7 @@
 package porcupine
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -81,8 +82,8 @@ type Event struct {
 // the model Step function should not modify the given state (or input or
 // output), but return a new state.
 //
-// Only the Init, Step, and Equal functions are necessary to specify if you
-// just want to test histories for linearizability.
+// Only the Init, Step (or StepContext), and Equal functions are necessary to
+// specify if you just want to test histories for linearizability.
 //
 // Implementing the partition functions can greatly improve performance. If
 // you're implementing the partition function, the model Init and Step
@@ -110,6 +111,10 @@ type Model struct {
 	// returns the new state. This function must be a pure function: it
 	// cannot mutate the given state.
 	Step func(state interface{}, input interface{}, output interface{}) (bool, interface{})
+	// StepContext is an optional context-aware Step function. If set, the
+	// checker and visualization replay call StepContext instead of Step,
+	// allowing the model to stop work promptly when a timeout expires.
+	StepContext func(ctx context.Context, state interface{}, input interface{}, output interface{}) (bool, interface{})
 	// Equality on states. If left nil, this package will use == as a
 	// fallback ([ShallowEqual]).
 	Equal func(state1, state2 interface{}) bool
@@ -152,6 +157,10 @@ type NondeterministicModel struct {
 	// the given state/input to produce the given output, this function
 	// should return an empty slice.
 	Step func(state interface{}, input interface{}, output interface{}) []interface{}
+	// StepContext is an optional context-aware Step function. If set, the
+	// checker calls StepContext instead of Step, allowing the model to stop
+	// work promptly when a timeout expires.
+	StepContext func(ctx context.Context, state interface{}, input interface{}, output interface{}) []interface{}
 	// Equality on states. If left nil, this package will use == as a
 	// fallback ([ShallowEqual]).
 	Equal func(state1, state2 interface{}) bool
@@ -212,6 +221,25 @@ func (nm *NondeterministicModel) ToModel() Model {
 	if describeOperationMetadata == nil {
 		describeOperationMetadata = defaultDescribeOperationMetadata
 	}
+	step := func(ctx context.Context, state, input, output interface{}) (bool, interface{}) {
+		states := state.([]interface{})
+		var allNextStates []interface{}
+		for _, state := range states {
+			if ctx.Err() != nil {
+				return false, nil
+			}
+			if nm.StepContext != nil {
+				allNextStates = append(allNextStates, nm.StepContext(ctx, state, input, output)...)
+			} else {
+				allNextStates = append(allNextStates, nm.Step(state, input, output)...)
+			}
+		}
+		if ctx.Err() != nil {
+			return false, nil
+		}
+		uniqueNextStates := merge(allNextStates, equal)
+		return len(uniqueNextStates) > 0, uniqueNextStates
+	}
 	return Model{
 		Partition:      nm.Partition,
 		PartitionEvent: nm.PartitionEvent,
@@ -220,14 +248,9 @@ func (nm *NondeterministicModel) ToModel() Model {
 			return merge(nm.Init(), nm.Equal)
 		},
 		Step: func(state, input, output interface{}) (bool, interface{}) {
-			states := state.([]interface{})
-			var allNextStates []interface{}
-			for _, state := range states {
-				allNextStates = append(allNextStates, nm.Step(state, input, output)...)
-			}
-			uniqueNextStates := merge(allNextStates, equal)
-			return len(uniqueNextStates) > 0, uniqueNextStates
+			return step(context.Background(), state, input, output)
 		},
+		StepContext: step,
 		// this operates on sets of states that have been merged, so we
 		// don't need to check inclusion in both directions
 		Equal: func(state1, state2 interface{}) bool {

--- a/porcupine_test.go
+++ b/porcupine_test.go
@@ -2,6 +2,7 @@ package porcupine
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type registerInput struct {
@@ -17,110 +20,184 @@ type registerInput struct {
 	value int
 }
 
+func registerInit() interface{} {
+	return 0
+}
+
+// step function: takes a state, input, and output, and returns whether it
+// was a legal operation, along with a new state
+func registerStep(state, input, output interface{}) (bool, interface{}) {
+	regInput := input.(registerInput)
+	if regInput.op == false {
+		return true, regInput.value // always ok to execute a put
+	}
+	readCorrectValue := output == state
+	return readCorrectValue, state // state is unchanged
+}
+
+func describeRegisterOperation(input, output interface{}) string {
+	inp := input.(registerInput)
+	switch inp.op {
+	case true:
+		return fmt.Sprintf("get() -> '%d'", output.(int))
+	case false:
+		return fmt.Sprintf("put('%d')", inp.value)
+	}
+	return "<invalid>" // unreachable
+}
+
 // a sequential specification of a register
 var registerModel = Model{
-	Init: func() interface{} {
-		return 0
+	Init:              registerInit,
+	Step:              registerStep,
+	DescribeOperation: describeRegisterOperation,
+}
+
+var registerStepContextModel = Model{
+	Init: registerInit,
+	StepContext: func(_ context.Context, state, input, output interface{}) (bool, interface{}) {
+		return registerStep(state, input, output)
 	},
-	// step function: takes a state, input, and output, and returns whether it
-	// was a legal operation, along with a new state
-	Step: func(state, input, output interface{}) (bool, interface{}) {
-		regInput := input.(registerInput)
-		if regInput.op == false {
-			return true, regInput.value // always ok to execute a put
-		} else {
-			readCorrectValue := output == state
-			return readCorrectValue, state // state is unchanged
-		}
-	},
-	DescribeOperation: func(input, output interface{}) string {
-		inp := input.(registerInput)
-		switch inp.op {
-		case true:
-			return fmt.Sprintf("get() -> '%d'", output.(int))
-		case false:
-			return fmt.Sprintf("put('%d')", inp.value)
-		}
-		return "<invalid>" // unreachable
-	},
+	DescribeOperation: describeRegisterOperation,
+}
+
+type registerModelVariant struct {
+	name  string
+	model Model
+}
+
+func registerModelVariants() []registerModelVariant {
+	return []registerModelVariant{
+		{"step", registerModel},
+		{"step_context", registerStepContextModel},
+	}
 }
 
 func TestRegisterModel(t *testing.T) {
 	// examples taken from http://nil.csail.mit.edu/6.824/2017/quizzes/q2-17-ans.pdf
 	// section VII
 
-	ops := []Operation{
-		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60},
-	}
-	res := CheckOperations(registerModel, ops)
-	if res != true {
-		t.Fatal("expected operations to be linearizable")
-	}
+	for _, tt := range registerModelVariants() {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.model
 
-	// same example as above, but with Event
-	events := []Event{
-		{ClientId: 0, Kind: CallEvent, Value: registerInput{false, 100}, Id: 0},
-		{ClientId: 1, Kind: CallEvent, Value: registerInput{true, 0}, Id: 1},
-		{ClientId: 2, Kind: CallEvent, Value: registerInput{true, 0}, Id: 2},
-		{ClientId: 2, Kind: ReturnEvent, Value: 0, Id: 2},
-		{ClientId: 1, Kind: ReturnEvent, Value: 100, Id: 1},
-		{ClientId: 0, Kind: ReturnEvent, Value: 0, Id: 0},
-	}
-	res = CheckEvents(registerModel, events)
-	if res != true {
-		t.Fatal("expected operations to be linearizable")
-	}
+			ops := []Operation{
+				{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100},
+				{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75},
+				{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60},
+			}
+			res := CheckOperations(model, ops)
+			if res != true {
+				t.Fatal("expected operations to be linearizable")
+			}
 
-	ops = []Operation{
-		{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 30},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90},
-	}
-	res = CheckOperations(registerModel, ops)
-	if res != false {
-		t.Fatal("expected operations to not be linearizable")
-	}
+			// same example as above, but with Event
+			events := []Event{
+				{ClientId: 0, Kind: CallEvent, Value: registerInput{false, 100}, Id: 0},
+				{ClientId: 1, Kind: CallEvent, Value: registerInput{true, 0}, Id: 1},
+				{ClientId: 2, Kind: CallEvent, Value: registerInput{true, 0}, Id: 2},
+				{ClientId: 2, Kind: ReturnEvent, Value: 0, Id: 2},
+				{ClientId: 1, Kind: ReturnEvent, Value: 100, Id: 1},
+				{ClientId: 0, Kind: ReturnEvent, Value: 0, Id: 0},
+			}
+			res = CheckEvents(model, events)
+			if res != true {
+				t.Fatal("expected operations to be linearizable")
+			}
 
-	// same example as above, but with Event
-	events = []Event{
-		{ClientId: 0, Kind: CallEvent, Value: registerInput{false, 200}, Id: 0},
-		{ClientId: 1, Kind: CallEvent, Value: registerInput{true, 0}, Id: 1},
-		{ClientId: 1, Kind: ReturnEvent, Value: 200, Id: 1},
-		{ClientId: 2, Kind: CallEvent, Value: registerInput{true, 0}, Id: 2},
-		{ClientId: 2, Kind: ReturnEvent, Value: 0, Id: 2},
-		{ClientId: 0, Kind: ReturnEvent, Value: 0, Id: 0},
-	}
-	res = CheckEvents(registerModel, events)
-	if res != false {
-		t.Fatal("expected operations to not be linearizable")
+			ops = []Operation{
+				{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100},
+				{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 30},
+				{ClientId: 2, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90},
+			}
+			res = CheckOperations(model, ops)
+			if res != false {
+				t.Fatal("expected operations to not be linearizable")
+			}
+
+			// same example as above, but with Event
+			events = []Event{
+				{ClientId: 0, Kind: CallEvent, Value: registerInput{false, 200}, Id: 0},
+				{ClientId: 1, Kind: CallEvent, Value: registerInput{true, 0}, Id: 1},
+				{ClientId: 1, Kind: ReturnEvent, Value: 200, Id: 1},
+				{ClientId: 2, Kind: CallEvent, Value: registerInput{true, 0}, Id: 2},
+				{ClientId: 2, Kind: ReturnEvent, Value: 0, Id: 2},
+				{ClientId: 0, Kind: ReturnEvent, Value: 0, Id: 0},
+			}
+			res = CheckEvents(model, events)
+			if res != false {
+				t.Fatal("expected operations to not be linearizable")
+			}
+		})
 	}
 }
 
 func TestZeroDuration(t *testing.T) {
+	for _, tt := range registerModelVariants() {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.model
+
+			ops := []Operation{
+				{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100},
+				{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75},
+				{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30},
+				{ClientId: 3, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30},
+			}
+			res, info := CheckOperationsVerbose(model, ops, 0)
+			if res != Ok {
+				t.Fatal("expected operations to be linearizable")
+			}
+
+			visualizeTempFile(t, model, info)
+
+			ops = []Operation{
+				{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100},
+				{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10},
+				{ClientId: 2, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10},
+				{ClientId: 3, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90},
+			}
+			res, _ = CheckOperationsVerbose(model, ops, 0)
+			if res != Illegal {
+				t.Fatal("expected operations to not be linearizable")
+			}
+		})
+	}
+}
+
+func TestVerboseTimeoutCancelsStepContext(t *testing.T) {
+	var stepCalls int32
+	model := Model{
+		Init: func() interface{} {
+			return 0
+		},
+		Step: func(state, input, output interface{}) (bool, interface{}) {
+			atomic.AddInt32(&stepCalls, 1)
+			return true, state
+		},
+		StepContext: func(ctx context.Context, state, input, output interface{}) (bool, interface{}) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(2 * time.Second):
+			}
+			return false, nil
+		},
+	}
 	ops := []Operation{
-		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30},
-		{ClientId: 3, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 30},
-	}
-	res, info := CheckOperationsVerbose(registerModel, ops, 0)
-	if res != Ok {
-		t.Fatal("expected operations to be linearizable")
+		{ClientId: 0, Input: "input", Call: 0, Output: "output", Return: 1},
 	}
 
-	visualizeTempFile(t, registerModel, info)
+	start := time.Now()
+	res, _ := CheckOperationsVerbose(model, ops, 20*time.Millisecond)
+	elapsed := time.Since(start)
 
-	ops = []Operation{
-		{ClientId: 0, Input: registerInput{false, 200}, Call: 0, Output: 0, Return: 100},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 10, Output: 200, Return: 10},
-		{ClientId: 3, Input: registerInput{true, 0}, Call: 40, Output: 0, Return: 90},
+	if res != Unknown {
+		t.Fatalf("expected timeout result %v, got %v", Unknown, res)
 	}
-	res, _ = CheckOperationsVerbose(registerModel, ops, 0)
-	if res != Illegal {
-		t.Fatal("expected operations to not be linearizable")
+	if elapsed > time.Second {
+		t.Fatalf("expected timeout to return promptly, took %s", elapsed)
+	}
+	if calls := atomic.LoadInt32(&stepCalls); calls != 0 {
+		t.Fatalf("expected StepContext to be used instead of Step, Step calls: %d", calls)
 	}
 }
 
@@ -1696,6 +1773,79 @@ func TestNondeterministicRegisterModel(t *testing.T) {
 	visualizeTempFile(t, model, info)
 }
 
+func TestNondeterministicModelToModelUsesStepContext(t *testing.T) {
+	var stepCalls int32
+	nondeterministicModel := NondeterministicModel{
+		Init: func() []interface{} {
+			return []interface{}{0, 1}
+		},
+		Step: func(state interface{}, input interface{}, output interface{}) []interface{} {
+			t.Fatal("expected StepContext to be used instead of Step")
+			return nil
+		},
+		StepContext: func(ctx context.Context, state interface{}, input interface{}, output interface{}) []interface{} {
+			atomic.AddInt32(&stepCalls, 1)
+			if ctx.Err() != nil {
+				return nil
+			}
+			return []interface{}{state.(int) + 1}
+		},
+		Equal: func(state1 interface{}, state2 interface{}) bool {
+			return state1.(int) == state2.(int)
+		},
+	}
+	model := nondeterministicModel.ToModel()
+
+	ok, newState := model.StepContext(context.Background(), model.Init(), nil, nil)
+	if !ok {
+		t.Fatal("expected context-aware nondeterministic step to succeed")
+	}
+	if !reflect.DeepEqual(newState, []interface{}{1, 2}) {
+		t.Fatalf("expected next states %v, got %v", []interface{}{1, 2}, newState)
+	}
+	if calls := atomic.LoadInt32(&stepCalls); calls != 2 {
+		t.Fatalf("expected one StepContext call per initial state, got %d", calls)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok, _ = model.StepContext(ctx, model.Init(), nil, nil)
+	if ok {
+		t.Fatal("expected canceled context-aware nondeterministic step to fail")
+	}
+	if calls := atomic.LoadInt32(&stepCalls); calls != 2 {
+		t.Fatalf("expected canceled context to stop before calling StepContext, got %d calls", calls)
+	}
+}
+
+func TestNondeterministicModelToModelWrapsStep(t *testing.T) {
+	var stepCalls int32
+	nondeterministicModel := NondeterministicModel{
+		Init: func() []interface{} {
+			return []interface{}{1}
+		},
+		Step: func(state interface{}, input interface{}, output interface{}) []interface{} {
+			atomic.AddInt32(&stepCalls, 1)
+			return []interface{}{state.(int) + 1}
+		},
+		Equal: func(state1 interface{}, state2 interface{}) bool {
+			return state1.(int) == state2.(int)
+		},
+	}
+	model := nondeterministicModel.ToModel()
+
+	ok, newState := model.StepContext(context.Background(), model.Init(), nil, nil)
+	if !ok {
+		t.Fatal("expected legacy nondeterministic step to succeed")
+	}
+	if !reflect.DeepEqual(newState, []interface{}{2}) {
+		t.Fatalf("expected next state %v, got %v", []interface{}{2}, newState)
+	}
+	if calls := atomic.LoadInt32(&stepCalls); calls != 1 {
+		t.Fatalf("expected legacy Step to be called once, got %d", calls)
+	}
+}
+
 func TestCheckNoPartitions(t *testing.T) {
 	ops := []Operation{}
 	res, _ := CheckOperationsVerbose(kvModel, ops, 0)
@@ -1706,40 +1856,46 @@ func TestCheckNoPartitions(t *testing.T) {
 
 func TestRegisterModelMetadata(t *testing.T) {
 	// similar to TestRegisterModel but with metadata
-	ops := []Operation{
-		{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100, Metadata: "meta1"},
-		{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75, Metadata: "meta2"},
-		{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60, Metadata: "meta3"},
-	}
-	res, info := CheckOperationsVerbose(registerModel, ops, 0)
-	if res != Ok {
-		t.Fatal("expected operations to be linearizable")
-	}
+	for _, tt := range registerModelVariants() {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.model
 
-	// Verify metadata propagation to internal history
-	// We expect 3 operations * 2 entries (call+return) = 6 entries
-	if len(info.history) != 1 {
-		t.Fatalf("expected 1 partition, got %d", len(info.history))
-	}
-	entries := info.history[0]
-	if len(entries) != 6 {
-		t.Fatalf("expected 6 entries, got %d", len(entries))
-	}
+			ops := []Operation{
+				{ClientId: 0, Input: registerInput{false, 100}, Call: 0, Output: 0, Return: 100, Metadata: "meta1"},
+				{ClientId: 1, Input: registerInput{true, 0}, Call: 25, Output: 100, Return: 75, Metadata: "meta2"},
+				{ClientId: 2, Input: registerInput{true, 0}, Call: 30, Output: 0, Return: 60, Metadata: "meta3"},
+			}
+			res, info := CheckOperationsVerbose(model, ops, 0)
+			if res != Ok {
+				t.Fatal("expected operations to be linearizable")
+			}
 
-	// We can map IDs to metadata to verify.
-	expectedMeta := map[int]string{
-		0: "meta1",
-		1: "meta2",
-		2: "meta3",
-	}
+			// Verify metadata propagation to internal history
+			// We expect 3 operations * 2 entries (call+return) = 6 entries
+			if len(info.history) != 1 {
+				t.Fatalf("expected 1 partition, got %d", len(info.history))
+			}
+			entries := info.history[0]
+			if len(entries) != 6 {
+				t.Fatalf("expected 6 entries, got %d", len(entries))
+			}
 
-	for _, e := range entries {
-		if e.metadata == nil {
-			t.Errorf("entry %d (id %d) metadata is empty", e.time, e.id)
-			continue
-		}
-		if expectedMeta[e.id] != e.metadata {
-			t.Errorf("entry %d (id %d) expected metadata %s, got %s", e.time, e.id, expectedMeta[e.id], e.metadata)
-		}
+			// We can map IDs to metadata to verify.
+			expectedMeta := map[int]string{
+				0: "meta1",
+				1: "meta2",
+				2: "meta3",
+			}
+
+			for _, e := range entries {
+				if e.metadata == nil {
+					t.Errorf("entry %d (id %d) metadata is empty", e.time, e.id)
+					continue
+				}
+				if expectedMeta[e.id] != e.metadata {
+					t.Errorf("entry %d (id %d) expected metadata %s, got %s", e.time, e.id, expectedMeta[e.id], e.metadata)
+				}
+			}
+		})
 	}
 }

--- a/visualization.go
+++ b/visualization.go
@@ -1,6 +1,7 @@
 package porcupine
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -184,7 +185,7 @@ func computeVisualizationData(model Model, info LinearizationInfo) visualization
 			state := model.Init()
 			for j, histId := range partial {
 				var ok bool
-				ok, state = model.Step(state, callValue[histId], returnValue[histId])
+				ok, state = modelStep(context.Background(), model, state, callValue[histId], returnValue[histId])
 				if !ok {
 					panic("valid partial linearization returned non-ok result from model step")
 				}

--- a/visualization_test.go
+++ b/visualization_test.go
@@ -73,53 +73,59 @@ func TestVisualizationMultipleLengths(t *testing.T) {
 func TestRegisterModelReadme(t *testing.T) {
 	// basically the code from the README
 
-	events := []Event{
-		// C0: Write(100)
-		{Kind: CallEvent, Value: registerInput{false, 100}, Id: 0, ClientId: 0},
-		// C1: Read()
-		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1},
-		// C2: Read()
-		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 2, ClientId: 2},
-		// C2: Completed Read -> 0
-		{Kind: ReturnEvent, Value: 0, Id: 2, ClientId: 2},
-		// C1: Completed Read -> 100
-		{Kind: ReturnEvent, Value: 100, Id: 1, ClientId: 1},
-		// C0: Completed Write
-		{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0},
+	for _, tt := range registerModelVariants() {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.model
+
+			events := []Event{
+				// C0: Write(100)
+				{Kind: CallEvent, Value: registerInput{false, 100}, Id: 0, ClientId: 0},
+				// C1: Read()
+				{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1},
+				// C2: Read()
+				{Kind: CallEvent, Value: registerInput{true, 0}, Id: 2, ClientId: 2},
+				// C2: Completed Read -> 0
+				{Kind: ReturnEvent, Value: 0, Id: 2, ClientId: 2},
+				// C1: Completed Read -> 100
+				{Kind: ReturnEvent, Value: 100, Id: 1, ClientId: 1},
+				// C0: Completed Write
+				{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0},
+			}
+
+			res, info := CheckEventsVerbose(model, events, 0)
+			// returns true
+
+			if res != Ok {
+				t.Fatal("expected operations to be linearizable")
+			}
+
+			visualizeTempFile(t, model, info)
+
+			events = []Event{
+				// C0: Write(200)
+				{Kind: CallEvent, Value: registerInput{false, 200}, Id: 0, ClientId: 0},
+				// C1: Read()
+				{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1},
+				// C1: Completed Read -> 200
+				{Kind: ReturnEvent, Value: 200, Id: 1, ClientId: 1},
+				// C2: Read()
+				{Kind: CallEvent, Value: registerInput{true, 0}, Id: 2, ClientId: 2},
+				// C2: Completed Read -> 0
+				{Kind: ReturnEvent, Value: 0, Id: 2, ClientId: 2},
+				// C0: Completed Write
+				{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0},
+			}
+
+			res, info = CheckEventsVerbose(model, events, 0)
+			// returns false
+
+			if res != Illegal {
+				t.Fatal("expected operations not to be linearizable")
+			}
+
+			visualizeTempFile(t, model, info)
+		})
 	}
-
-	res, info := CheckEventsVerbose(registerModel, events, 0)
-	// returns true
-
-	if res != Ok {
-		t.Fatal("expected operations to be linearizable")
-	}
-
-	visualizeTempFile(t, registerModel, info)
-
-	events = []Event{
-		// C0: Write(200)
-		{Kind: CallEvent, Value: registerInput{false, 200}, Id: 0, ClientId: 0},
-		// C1: Read()
-		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1},
-		// C1: Completed Read -> 200
-		{Kind: ReturnEvent, Value: 200, Id: 1, ClientId: 1},
-		// C2: Read()
-		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 2, ClientId: 2},
-		// C2: Completed Read -> 0
-		{Kind: ReturnEvent, Value: 0, Id: 2, ClientId: 2},
-		// C0: Completed Write
-		{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0},
-	}
-
-	res, info = CheckEventsVerbose(registerModel, events, 0)
-	// returns false
-
-	if res != Illegal {
-		t.Fatal("expected operations not to be linearizable")
-	}
-
-	visualizeTempFile(t, registerModel, info)
 }
 
 func TestVisualizationLarge(t *testing.T) {
@@ -490,111 +496,115 @@ func TestVisualizationMetadataAlwaysVisible(t *testing.T) {
 }
 
 func TestVisualizationEventMetadata(t *testing.T) {
-	model := registerModel
-	model.DescribeOperationMetadata = func(info interface{}) string {
-		if info == nil {
-			return ""
-		}
-		return fmt.Sprintf("event-meta: %v", info)
-	}
+	for _, tt := range registerModelVariants() {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.model
+			model.DescribeOperationMetadata = func(info interface{}) string {
+				if info == nil {
+					return ""
+				}
+				return fmt.Sprintf("event-meta: %v", info)
+			}
 
-	events := []Event{
-		// C0: Write(100) with metadata on both CallEvent and ReturnEvent (Return should take precedence)
-		{Kind: CallEvent, Value: registerInput{false, 100}, Id: 0, ClientId: 0, Metadata: "write-call-meta-IGNORED"},
-		// C1: Read() with metadata only on CallEvent
-		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1, Metadata: "read-call-meta"},
-		// C2: Read() with metadata only on ReturnEvent
-		{Kind: CallEvent, Value: registerInput{true, 0}, Id: 2, ClientId: 2},
-		// C1: Completed Read -> 100 (no metadata on return, should use call metadata)
-		{Kind: ReturnEvent, Value: 100, Id: 1, ClientId: 1},
-		// C2: Completed Read -> 100 (metadata on ReturnEvent only)
-		{Kind: ReturnEvent, Value: 100, Id: 2, ClientId: 2, Metadata: "read-return-meta"},
-		// C0: Completed Write (metadata on ReturnEvent should take precedence over CallEvent)
-		{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0, Metadata: "write-return-meta"},
-	}
+			events := []Event{
+				// C0: Write(100) with metadata on both CallEvent and ReturnEvent (Return should take precedence)
+				{Kind: CallEvent, Value: registerInput{false, 100}, Id: 0, ClientId: 0, Metadata: "write-call-meta-IGNORED"},
+				// C1: Read() with metadata only on CallEvent
+				{Kind: CallEvent, Value: registerInput{true, 0}, Id: 1, ClientId: 1, Metadata: "read-call-meta"},
+				// C2: Read() with metadata only on ReturnEvent
+				{Kind: CallEvent, Value: registerInput{true, 0}, Id: 2, ClientId: 2},
+				// C1: Completed Read -> 100 (no metadata on return, should use call metadata)
+				{Kind: ReturnEvent, Value: 100, Id: 1, ClientId: 1},
+				// C2: Completed Read -> 100 (metadata on ReturnEvent only)
+				{Kind: ReturnEvent, Value: 100, Id: 2, ClientId: 2, Metadata: "read-return-meta"},
+				// C0: Completed Write (metadata on ReturnEvent should take precedence over CallEvent)
+				{Kind: ReturnEvent, Value: 0, Id: 0, ClientId: 0, Metadata: "write-return-meta"},
+			}
 
-	res, info := CheckEventsVerbose(model, events, 0)
-	if res != Ok {
-		t.Fatal("expected operations to be linearizable")
-	}
+			res, info := CheckEventsVerbose(model, events, 0)
+			if res != Ok {
+				t.Fatal("expected operations to be linearizable")
+			}
 
-	// Part 1: Test data structure directly
-	data := computeVisualizationData(model, info)
+			// Part 1: Test data structure directly
+			data := computeVisualizationData(model, info)
 
-	if len(data.Partitions) != 1 {
-		t.Fatalf("expected 1 partition, got %d", len(data.Partitions))
-	}
-	history := data.Partitions[0].History
-	if len(history) != 3 {
-		t.Fatalf("expected 3 history elements, got %d", len(history))
-	}
+			if len(data.Partitions) != 1 {
+				t.Fatalf("expected 1 partition, got %d", len(data.Partitions))
+			}
+			history := data.Partitions[0].History
+			if len(history) != 3 {
+				t.Fatalf("expected 3 history elements, got %d", len(history))
+			}
 
-	// Verify metadata is associated with the correct operations
-	// history[0] = operation Id=0 (Write, ClientId=0)
-	if history[0].ClientId != 0 {
-		t.Errorf("expected history[0].ClientId=0, got %d", history[0].ClientId)
-	}
-	if history[0].Metadata != "event-meta: write-return-meta" {
-		t.Errorf("expected history[0].Metadata='event-meta: write-return-meta', got '%s'", history[0].Metadata)
-	}
+			// Verify metadata is associated with the correct operations
+			// history[0] = operation Id=0 (Write, ClientId=0)
+			if history[0].ClientId != 0 {
+				t.Errorf("expected history[0].ClientId=0, got %d", history[0].ClientId)
+			}
+			if history[0].Metadata != "event-meta: write-return-meta" {
+				t.Errorf("expected history[0].Metadata='event-meta: write-return-meta', got '%s'", history[0].Metadata)
+			}
 
-	// history[1] = operation Id=1 (Read, ClientId=1)
-	if history[1].ClientId != 1 {
-		t.Errorf("expected history[1].ClientId=1, got %d", history[1].ClientId)
-	}
-	if history[1].Metadata != "event-meta: read-call-meta" {
-		t.Errorf("expected history[1].Metadata='event-meta: read-call-meta', got '%s'", history[1].Metadata)
-	}
+			// history[1] = operation Id=1 (Read, ClientId=1)
+			if history[1].ClientId != 1 {
+				t.Errorf("expected history[1].ClientId=1, got %d", history[1].ClientId)
+			}
+			if history[1].Metadata != "event-meta: read-call-meta" {
+				t.Errorf("expected history[1].Metadata='event-meta: read-call-meta', got '%s'", history[1].Metadata)
+			}
 
-	// history[2] = operation Id=2 (Read, ClientId=2)
-	if history[2].ClientId != 2 {
-		t.Errorf("expected history[2].ClientId=2, got %d", history[2].ClientId)
-	}
-	if history[2].Metadata != "event-meta: read-return-meta" {
-		t.Errorf("expected history[2].Metadata='event-meta: read-return-meta', got '%s'", history[2].Metadata)
-	}
+			// history[2] = operation Id=2 (Read, ClientId=2)
+			if history[2].ClientId != 2 {
+				t.Errorf("expected history[2].ClientId=2, got %d", history[2].ClientId)
+			}
+			if history[2].Metadata != "event-meta: read-return-meta" {
+				t.Errorf("expected history[2].Metadata='event-meta: read-return-meta', got '%s'", history[2].Metadata)
+			}
 
-	// Part 2: Test HTML output (end-to-end verification)
-	file, err := os.CreateTemp("", "porcupine_test_event_metadata_*.html")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	defer os.Remove(file.Name())
-	defer file.Close()
+			// Part 2: Test HTML output (end-to-end verification)
+			file, err := os.CreateTemp("", "porcupine_test_event_metadata_*.html")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			defer os.Remove(file.Name())
+			defer file.Close()
 
-	if err := Visualize(model, info, file); err != nil {
-		t.Fatalf("Visualize failed: %v", err)
-	}
+			if err := Visualize(model, info, file); err != nil {
+				t.Fatalf("Visualize failed: %v", err)
+			}
 
-	content, err := os.ReadFile(file.Name())
-	if err != nil {
-		t.Fatalf("failed to read generated HTML: %v", err)
-	}
+			content, err := os.ReadFile(file.Name())
+			if err != nil {
+				t.Fatalf("failed to read generated HTML: %v", err)
+			}
 
-	// Extract JSON from HTML: "const data = {...}"
-	re := regexp.MustCompile(`const data = (\{.*\})`)
-	matches := re.FindSubmatch(content)
-	if len(matches) < 2 {
-		t.Fatal("failed to extract JSON data from HTML")
-	}
+			// Extract JSON from HTML: "const data = {...}"
+			re := regexp.MustCompile(`const data = (\{.*\})`)
+			matches := re.FindSubmatch(content)
+			if len(matches) < 2 {
+				t.Fatal("failed to extract JSON data from HTML")
+			}
 
-	var htmlData visualizationData
-	if err := json.Unmarshal(matches[1], &htmlData); err != nil {
-		t.Fatalf("failed to unmarshal JSON from HTML: %v", err)
-	}
+			var htmlData visualizationData
+			if err := json.Unmarshal(matches[1], &htmlData); err != nil {
+				t.Fatalf("failed to unmarshal JSON from HTML: %v", err)
+			}
 
-	// Verify HTML contains correctly structured data
-	if len(htmlData.Partitions) != 1 || len(htmlData.Partitions[0].History) != 3 {
-		t.Fatalf("unexpected HTML data structure")
-	}
-	htmlHistory := htmlData.Partitions[0].History
-	if htmlHistory[0].Metadata != "event-meta: write-return-meta" {
-		t.Errorf("HTML: expected history[0].Metadata='event-meta: write-return-meta', got '%s'", htmlHistory[0].Metadata)
-	}
-	if htmlHistory[1].Metadata != "event-meta: read-call-meta" {
-		t.Errorf("HTML: expected history[1].Metadata='event-meta: read-call-meta', got '%s'", htmlHistory[1].Metadata)
-	}
-	if htmlHistory[2].Metadata != "event-meta: read-return-meta" {
-		t.Errorf("HTML: expected history[2].Metadata='event-meta: read-return-meta', got '%s'", htmlHistory[2].Metadata)
+			// Verify HTML contains correctly structured data
+			if len(htmlData.Partitions) != 1 || len(htmlData.Partitions[0].History) != 3 {
+				t.Fatalf("unexpected HTML data structure")
+			}
+			htmlHistory := htmlData.Partitions[0].History
+			if htmlHistory[0].Metadata != "event-meta: write-return-meta" {
+				t.Errorf("HTML: expected history[0].Metadata='event-meta: write-return-meta', got '%s'", htmlHistory[0].Metadata)
+			}
+			if htmlHistory[1].Metadata != "event-meta: read-call-meta" {
+				t.Errorf("HTML: expected history[1].Metadata='event-meta: read-call-meta', got '%s'", htmlHistory[1].Metadata)
+			}
+			if htmlHistory[2].Metadata != "event-meta: read-return-meta" {
+				t.Errorf("HTML: expected history[2].Metadata='event-meta: read-return-meta', got '%s'", htmlHistory[2].Metadata)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The `Step` interface currently doesn't have a way to propagate timeout information to the interface implementation. Under certain condition as mentioned in the issue, we can run into situations that the validation timeout is not respected, causing the CI to fail.

This PR attempts to resolve this by adding a new `StepContext` interface, which 
- uses `context` to propagate the timeout
- keeps `Step` for backward compatibility (if both `StepContext` and `Step` is defined, we will use `StepContext` instead of `Step`)

Ref: https://github.com/anishathalye/porcupine/issues/44